### PR TITLE
Expose PUT endpoint and save to mongo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+# IntelliJ files
+.idea/
+*.iml

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ test: test-unit
 test-unit:
 	mvn test
 
+.PHONY: coverage
+coverage:
+	mvn verify
+
 .PHONY: package
 package:
 ifndef version
@@ -45,7 +49,7 @@ endif
 	rm -rf $(tmpdir)
 
 .PHONY: dist
-dist: clean package
+dist: clean build package coverage
 
 .PHONY: publish
 publish:

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 
         <!-- Internal -->
         <structured-logging.version>1.9.12</structured-logging.version>
@@ -189,6 +190,54 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution model. -->
+                            <destFile>${sonar.jacoco.reports}/jacoco.exec</destFile>
+                            <propertyName>surefireArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${sonar.jacoco.reports}/jacoco.exec</dataFile>
+                            <outputDirectory>${sonar.jacoco.reports}/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution model. -->
+                            <destFile>${sonar.jacoco.reports}/jacoco-it.exec</destFile>
+                            <propertyName>failsafeArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${sonar.jacoco.reports}/jacoco-it.exec</dataFile>
+                            <outputDirectory>${sonar.jacoco.reports}/jacoco-it</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
-        <artifactId>companies-house-spring-boot-parent</artifactId>
-        <version>1.5.0-rc1</version>
+        <artifactId>companies-house-parent</artifactId>
+        <version>1.3.1</version>
         <relativePath />
     </parent>
     <artifactId>psc-data-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/models/*.class</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>pre-unit-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
-        <artifactId>companies-house-parent</artifactId>
-        <version>1.3.0</version>
+        <artifactId>companies-house-spring-boot-parent</artifactId>
+        <version>1.5.0-rc1</version>
         <relativePath />
     </parent>
     <artifactId>psc-data-api</artifactId>
@@ -23,6 +23,23 @@
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
 
+        <!-- Internal -->
+        <structured-logging.version>1.9.12</structured-logging.version>
+        <private-api-sdk-java.version>2.0.237</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
+        <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
+
+        <!-- tests -->
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
+        <io-cucumber.version>7.2.3</io-cucumber.version>
+        <test-containers.version>1.16.3</test-containers.version>
+        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+        <assertj-core.version>3.22.0</assertj-core.version>
+        <skip.integration.tests>false</skip.integration.tests>
+        <skip.unit.tests>false</skip.unit.tests>
+        <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
+
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,
             ${project.basedir}/target/site/jacoco-it/jacoco.xml
@@ -35,6 +52,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${test-containers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -53,10 +77,46 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>structured-logging</artifactId>
+            <version>${structured-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-manager-java-library</artifactId>
+            <version>${api-sdk-manager-java-library.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-helper-java</artifactId>
+            <version>${api-helper-java-library.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/routes.yaml
+++ b/routes.yaml
@@ -1,0 +1,6 @@
+app_name: psc-data-api
+group: api
+weight: 905
+routes:
+  1: ^/persons-with-significant-control/healthcheck
+  2: ^/company/(.*)/persons-with-significant-control/(.*)/full_record

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/PscDataApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/PscDataApiApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class PscDataApiApplication {
+    public static final String APPLICATION_NAME_SPACE = "psc-data-api";
 
     public static void main(String[] args) {
         SpringApplication.run(PscDataApiApplication.class, args);

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfig.java
@@ -1,0 +1,57 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.function.Supplier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.gov.companieshouse.pscdataapi.converter.CompanyPscReadConverter;
+import uk.gov.companieshouse.pscdataapi.converter.CompanyPscWriteConverter;
+import uk.gov.companieshouse.pscdataapi.serialization.LocalDateDeSerializer;
+import uk.gov.companieshouse.pscdataapi.serialization.LocalDateSerializer;
+
+@Configuration
+public class ApplicationConfig {
+
+    /**
+     * mongoCustomConversions.
+     *
+     * @return MongoCustomConversions.
+     */
+    @Bean
+    public MongoCustomConversions mongoCustomConversions() {
+        ObjectMapper objectMapper = mongoDbObjectMapper();
+        return new MongoCustomConversions(List.of(new CompanyPscWriteConverter(objectMapper),
+                new CompanyPscReadConverter(objectMapper)));
+    }
+
+    @Bean
+    public Supplier<String> offsetDateTimeGenerator() {
+        return () -> String.valueOf(OffsetDateTime.now());
+    }
+
+    /**
+     * Mongo DB Object Mapper.
+     *
+     * @return ObjectMapper.
+     */
+    private ObjectMapper mongoDbObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(LocalDate.class, new LocalDateSerializer());
+        module.addDeserializer(LocalDate.class, new LocalDateDeSerializer());
+        objectMapper.registerModule(module);
+        return objectMapper;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfig.java
@@ -1,0 +1,133 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
+import uk.gov.companieshouse.pscdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
+
+@ControllerAdvice
+public class ExceptionHandlerConfig {
+    private final Logger logger;
+
+    @Autowired
+    public ExceptionHandlerConfig(Logger logger) {
+        this.logger = logger;
+    }
+
+    private static final String TIMESTAMP = "timestamp";
+    private static final String MESSAGE = "message";
+    private static final String EXCEPTION_ATTRIBUTE = "javax.servlet.error.exception";
+
+    /**
+     * Runtime exception handler. Acts as the catch-all scenario.
+    *
+    * @param ex      exception to handle.
+    * @param request request.
+    * @return error response to return.
+    */
+    @ExceptionHandler(value = {Exception.class})
+    public ResponseEntity<Object> handleException(Exception ex, WebRequest request) {
+        logger.error(String.format("Unexpected exception, response code: %s",
+                HttpStatus.INTERNAL_SERVER_ERROR), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put(TIMESTAMP, LocalDateTime.now());
+        responseBody.put(MESSAGE, "Unable to process the request.");
+        request.setAttribute(EXCEPTION_ATTRIBUTE, ex, 0);
+        return new ResponseEntity<>(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * IllegalArgumentException exception handler.
+    *
+    * @param ex      exception to handle.
+    * @param request request.
+    * @return error response to return.
+    */
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    public ResponseEntity<Object> handleNotFoundException(Exception ex, WebRequest request) {
+        logger.error(String.format("Resource not found, response code: %s",
+                HttpStatus.NOT_FOUND), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put(TIMESTAMP, LocalDateTime.now());
+        responseBody.put(MESSAGE, "Resource not found.");
+        request.setAttribute(EXCEPTION_ATTRIBUTE, ex, 0);
+        return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * MethodNotAllowedException exception handler.
+    *
+    * @param ex      exception to handle.
+    * @param request request.
+    * @return error response to return.
+    */
+    @ExceptionHandler(value = {MethodNotAllowedException.class,
+            HttpRequestMethodNotSupportedException.class})
+    public ResponseEntity<Object> handleMethodNotAllowedException(
+            Exception ex, WebRequest request) {
+        logger.error(String.format("Unable to process the request, response code: %s",
+                HttpStatus.METHOD_NOT_ALLOWED), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put(TIMESTAMP, LocalDateTime.now());
+        responseBody.put(MESSAGE, "Unable to process the request.");
+        request.setAttribute(EXCEPTION_ATTRIBUTE, ex, 0);
+        return new ResponseEntity<>(responseBody, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * ServiceUnavailableException exception handler.
+    * To be thrown when there are connection issues.
+    *
+    * @param ex      exception to handle.
+    * @param request request.
+    * @return error response to return.
+    */
+    @ExceptionHandler(value = {ServiceUnavailableException.class, DataAccessException.class})
+    public ResponseEntity<Object> handleServiceUnavailableException(Exception ex,
+                                                                    WebRequest request) {
+        logger.error(String.format("Service unavailable, response code: %s",
+                HttpStatus.SERVICE_UNAVAILABLE), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put(TIMESTAMP, LocalDateTime.now());
+        responseBody.put(MESSAGE, "Service unavailable.");
+        request.setAttribute(EXCEPTION_ATTRIBUTE, ex, 0);
+        return new ResponseEntity<>(responseBody, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * BadRequestException exception handler.
+    * Thrown when data is given in the wrong format.
+    *
+    * @param ex      exception to handle.
+    * @param request request.
+    * @return error response to return.
+    */
+    @ExceptionHandler(value = {BadRequestException.class, DateTimeParseException.class,
+            HttpMessageNotReadableException.class})
+    public ResponseEntity<Object> handleBadRequestException(Exception ex, WebRequest request) {
+        logger.error(String.format("Bad request, response code: %s", HttpStatus.BAD_REQUEST), ex);
+
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+        responseBody.put(TIMESTAMP, LocalDateTime.now());
+        responseBody.put(MESSAGE, "Bad request.");
+        request.setAttribute(EXCEPTION_ATTRIBUTE, ex, 0);
+        return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/LoggingConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/LoggingConfig.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Configuration class for logging.
+ */
+@Configuration
+public class LoggingConfig {
+
+    @Value("${logger.namespace}")
+    private String loggerNamespace;
+
+    /**
+     * Creates a logger with specified namespace.
+     *
+     * @return the {@link LoggerFactory} for the specified namespace
+     */
+    @Bean
+    public Logger logger() {
+        return LoggerFactory.getLogger(loggerNamespace);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/MongoDbConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/MongoDbConfig.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+
+@Configuration
+public class MongoDbConfig implements InitializingBean {
+
+    @Autowired
+    @Lazy
+    private MappingMongoConverter mappingMongoConverter;
+
+    // Remove _class field from data
+    @Override
+    public void afterPropertiesSet() {
+        mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/MongoPscConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/MongoPscConfig.java
@@ -1,0 +1,59 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class MongoPscConfig extends AbstractMongoClientConfiguration {
+
+    @Value("${spring.data.mongodb.name}")
+    private String databaseName;
+
+    @Value("${spring.data.mongodb.uri}")
+    private String databaseUri;
+
+    @Bean
+    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+        return new MongoTransactionManager(dbFactory);
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
+    }
+
+    protected String getDatabaseUri() {
+        return this.databaseUri;
+    }
+
+    @Override
+    public MongoClient mongoClient() {
+        final ConnectionString connectionString =
+                new ConnectionString(getDatabaseUri());
+        final MongoClientSettings mongoClientSettings = MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .build();
+        return MongoClients.create(mongoClientSettings);
+    }
+
+    @Bean
+    @Override
+    public MongoMappingContext mongoMappingContext(MongoCustomConversions customConversions) {
+        MongoMappingContext mappingContext = new MongoMappingContext();
+        mappingContext.setFieldNamingStrategy(new SnakeCaseFieldNamingStrategy());
+        return mappingContext;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
@@ -1,0 +1,46 @@
+package uk.gov.companieshouse.pscdataapi.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.pscdataapi.service.CompanyPscService;
+
+
+@RestController
+@RequestMapping(
+        path = "/company/{company_number}/persons-with-significant-control/"
+        + "{notification_id}/full_record", produces = "application/json")
+public class CompanyPscController {
+
+    @Autowired
+    CompanyPscService pscService;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("psc-data-api");
+
+    /**
+     * PUT endpoint for PSC record
+     * @param contextId context Id taken from header.
+     * @param request request payload.
+     * @return response.
+     */
+    @PutMapping(consumes = "application/json")
+    public ResponseEntity<Void> submitPscData(@RequestHeader("x-request-id") String contextId,
+                                              @RequestBody final FullRecordCompanyPSCApi request) {
+        try {
+            LOGGER.info("Payload received, inserting record...");
+            pscService.insertPscRecord(contextId, request);
+            return ResponseEntity.ok().build();
+        } catch (ServiceUnavailableException exception) {
+            LOGGER.info(exception.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/controller/HealthCheckController.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.pscdataapi.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+    @GetMapping("/healthcheck")
+    public ResponseEntity<Void> healthcheck() {
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscReadConverter.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscReadConverter.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.pscdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.springframework.core.convert.converter.Converter;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.pscdataapi.exceptions.FailedToConvertException;
+
+public class CompanyPscReadConverter implements Converter<Document, FullRecordCompanyPSCApi> {
+
+    private final ObjectMapper objectMapper;
+
+    public CompanyPscReadConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Read convertor.
+     * @param source source Document.
+     * @return psc API object.
+     */
+    @Override
+    public FullRecordCompanyPSCApi convert(Document source) {
+        try {
+            return objectMapper.readValue(source.toJson(), FullRecordCompanyPSCApi.class);
+        } catch (Exception ex) {
+            throw new FailedToConvertException(ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscWriteConverter.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscWriteConverter.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.pscdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import org.springframework.core.convert.converter.Converter;
+import uk.gov.companieshouse.pscdataapi.exceptions.FailedToConvertException;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+
+public class CompanyPscWriteConverter implements Converter<PscDocument, BasicDBObject> {
+
+    private final ObjectMapper objectMapper;
+
+    public CompanyPscWriteConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Write convertor.
+     * @param source source Document.
+     * @return psc BSON object.
+     */
+    @Override
+    public BasicDBObject convert(PscDocument source) {
+        try {
+            return BasicDBObject.parse(objectMapper.writeValueAsString(source));
+        } catch (Exception ex) {
+            throw new FailedToConvertException(ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRoles.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRoles.java
@@ -1,0 +1,38 @@
+package uk.gov.companieshouse.pscdataapi.data;
+
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+public enum CorporatePscRoles {
+    CORPORATE_PSC("corporate-entity-person-with-significant-control"),
+    CORPORATE_BO("corporate-entity-beneficial-owner");
+
+    private String role;
+
+    CorporatePscRoles(String role) {
+        this.role = role;
+    }
+
+    public static boolean includes(final PscRoles role) {
+        return includes(role.getRole());
+    }
+
+    /**
+     * Checks if enum contains entry.
+     * @param role the entry to check
+     * */
+    public static boolean includes(final String role) {
+        return EnumSet.allOf(CorporatePscRoles.class).stream()
+                .map(CorporatePscRoles::getRole)
+                .anyMatch(role::equals);
+    }
+
+
+    public static Stream<CorporatePscRoles> stream() {
+        return Stream.of(CorporatePscRoles.values());
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRoles.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRoles.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.pscdataapi.data;
+
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+public enum IndividualPscRoles {
+    INDIVIDUAL_PSC("individual-person-with-significant-control"),
+    LEGAL_PSC("legal-person-person-with-significant-control"),
+    INDIVIDUAL_BO("individual-beneficial-owner"),
+    LEGAL_BO("legal-person-beneficial-owner");
+
+    private String role;
+
+    IndividualPscRoles(String role) {
+        this.role = role;
+    }
+
+    public static boolean includes(final PscRoles role) {
+        return includes(role.getRole());
+    }
+
+    /**
+    * Checks if enum contains entry.
+    * @param role the entry to check
+    * */
+    public static boolean includes(final String role) {
+        return EnumSet.allOf(IndividualPscRoles.class).stream()
+                .map(IndividualPscRoles::getRole)
+                .anyMatch(role::equals);
+    }
+
+    public static Stream<IndividualPscRoles> stream() {
+        return Stream.of(IndividualPscRoles.values());
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/data/PscRoles.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/data/PscRoles.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.pscdataapi.data;
+
+import java.util.stream.Stream;
+
+public enum PscRoles {
+    INDIVIDUAL_PSC("individual-person-with-significant-control"),
+    CORPORATE_PSC("corporate-entity-person-with-significant-control"),
+    LEGAL_PSC("legal-person-person-with-significant-control"),
+    SUPER_SECURE_PSC("super-secure-person-with-significant-control"),
+
+    INDIVIDUAL_BO("individual-beneficial-owner"),
+    CORPORATE_BO("corporate-entity-beneficial-owner"),
+    LEGAL_BO("legal-person-beneficial-owner"),
+    SUPER_SECURE_BO("super-secure-beneficial-owner");
+
+    private String role;
+
+    PscRoles(String role) {
+        this.role = role;
+    }
+
+    public static Stream<PscRoles> stream() {
+        return Stream.of(PscRoles.values());
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/data/SecurePscRoles.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/data/SecurePscRoles.java
@@ -1,0 +1,38 @@
+package uk.gov.companieshouse.pscdataapi.data;
+
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+public enum SecurePscRoles {
+    SUPER_SECURE_PSC("super-secure-person-with-significant-control"),
+    SUPER_SECURE_BO("super-secure-beneficial-owner");
+
+    private String role;
+
+    SecurePscRoles(String role) {
+
+        this.role = role;
+    }
+
+    public static boolean includes(final PscRoles role) {
+        return includes(role.getRole());
+    }
+
+    /**
+     * Checks if enum contains entry.
+     * @param role the entry to check
+     * */
+    public static boolean includes(final String role) {
+        return EnumSet.allOf(SecurePscRoles.class).stream()
+                .map(SecurePscRoles::getRole)
+                .anyMatch(role::equals);
+    }
+
+    public static Stream<SecurePscRoles> stream() {
+        return Stream.of(SecurePscRoles.values());
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/BadRequestException.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.pscdataapi.exceptions;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/FailedToConvertException.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/FailedToConvertException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.pscdataapi.exceptions;
+
+public class FailedToConvertException extends RuntimeException {
+    public FailedToConvertException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/FailedToTransformException.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/FailedToTransformException.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.pscdataapi.exceptions;
+
+public class FailedToTransformException extends RuntimeException {
+
+    public FailedToTransformException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/MethodNotAllowedException.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/MethodNotAllowedException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.pscdataapi.exceptions;
+
+public class MethodNotAllowedException extends RuntimeException {
+    public MethodNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/ServiceUnavailableException.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/ServiceUnavailableException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.pscdataapi.exceptions;
+
+public class ServiceUnavailableException extends RuntimeException {
+    public ServiceUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/Address.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/Address.java
@@ -1,0 +1,190 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import java.util.Objects;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class Address {
+    @Field("address_line_1")
+    private String addressLine1;
+    @Field("address_line_2")
+    private String addressLine2;
+    @Field("country")
+    private String country;
+    @Field("locality")
+    private String locality;
+    @Field("postal_code")
+    private String postalCode;
+    @Field("premises")
+    private String premises;
+    @Field("region")
+    private String region;
+    @Field("care_of")
+    private String careOf;
+    @Field("po_box")
+    private String poBox;
+
+    public Address() {}
+
+    /**
+     * Contructor using SDK Address.
+     * @param address API Address object.
+     */
+    public Address(uk.gov.companieshouse.api.psc.Address address) {
+        this.addressLine1 = address.getAddressLine1();
+        this.addressLine2 = address.getAddressLine2();
+        this.country = address.getCountry();
+        this.locality = address.getLocality();
+        this.postalCode = address.getPostalCode();
+        this.premises = address.getPremises();
+        this.region = address.getRegion();
+        this.careOf = address.getCareOf();
+        this.poBox = address.getPoBox();
+    }
+
+    /**
+     * Contructor using SDK URA.
+     * @param address API URA object.
+     */
+    public Address(uk.gov.companieshouse.api.psc.UsualResidentialAddress address) {
+        this.addressLine1 = address.getAddressLine1();
+        this.addressLine2 = address.getAddressLine2();
+        this.country = address.getCountry();
+        this.locality = address.getLocality();
+        this.postalCode = address.getPostalCode();
+        this.premises = address.getPremises();
+        this.region = address.getRegion();
+        this.careOf = address.getCareOf();
+        this.poBox = address.getPoBox();
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public void setAddressLine1(String addressLine1) {
+        this.addressLine1 = addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public void setAddressLine2(String addressLine2) {
+        this.addressLine2 = addressLine2;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getLocality() {
+        return locality;
+    }
+
+    public void setLocality(String locality) {
+        this.locality = locality;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getPremises() {
+        return premises;
+    }
+
+    public void setPremises(String premises) {
+        this.premises = premises;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getCareOf() {
+        return careOf;
+    }
+
+    public void setCareOf(String careOf) {
+        this.careOf = careOf;
+    }
+
+    public String getPoBox() {
+        return poBox;
+    }
+
+    public void setPoBox(String poBox) {
+        this.poBox = poBox;
+    }
+
+    @Override
+    public String toString() {
+        return "Address{"
+                + "addressLine1='"
+                + addressLine1
+                + '\''
+                + ", addressLine2='"
+                + addressLine2
+                + '\''
+                + ", country='"
+                + country
+                + '\''
+                + ", locality='"
+                + locality
+                + '\''
+                + ", postalCode='"
+                + postalCode
+                + '\''
+                + ", premises='"
+                + premises
+                + '\''
+                + ", region='"
+                + region
+                + '\''
+                + ", careOf='"
+                + careOf
+                + '\''
+                + ", poBox='"
+                + poBox
+                + '\''
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        Address address = (Address) object;
+        return Objects.equals(addressLine1, address.addressLine1)
+                && Objects.equals(addressLine2, address.addressLine2)
+                && Objects.equals(country, address.country)
+                && Objects.equals(locality, address.locality)
+                && Objects.equals(postalCode, address.postalCode)
+                && Objects.equals(premises, address.premises)
+                && Objects.equals(region, address.region)
+                && Objects.equals(careOf, address.careOf)
+                && Objects.equals(poBox, address.poBox);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addressLine1, addressLine2, country, locality, postalCode,
+                premises, region, careOf, poBox);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/Created.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/Created.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import java.time.LocalDateTime;
+
+public class Created {
+
+    private LocalDateTime at;
+
+    public LocalDateTime getAt() {
+        return at;
+    }
+
+    public Created setAt(LocalDateTime at) {
+        this.at = at;
+        return this;
+    }
+}
+

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/DateOfBirth.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/DateOfBirth.java
@@ -1,0 +1,81 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import java.util.Objects;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class DateOfBirth {
+
+    @Field("day")
+    private Integer day;
+    @Field("month")
+    private Integer month;
+    @Field("year")
+    private Integer year;
+
+    public DateOfBirth() {}
+
+    /**
+     * Contructor using SDK DoB.
+     * @param dob API DoB object.
+     */
+    public DateOfBirth(uk.gov.companieshouse.api.psc.DateOfBirth dob) {
+        this.day = dob.getDay();
+        this.month = dob.getMonth();
+        this.year = dob.getYear();
+    }
+
+    public Integer getDay() {
+        return day;
+    }
+
+    public void setDay(Integer day) {
+        this.day = day;
+    }
+
+    public Integer getMonth() {
+        return month;
+    }
+
+    public void setMonth(Integer month) {
+        this.month = month;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer year) {
+        this.year = year;
+    }
+
+    @Override
+    public String toString() {
+        return "DateOfBirth{"
+                + "day="
+                + day
+                + ", month="
+                + month
+                + ", year="
+                + year
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        DateOfBirth that = (DateOfBirth) object;
+        return Objects.equals(day, that.day)
+                && Objects.equals(month, that.month)
+                && Objects.equals(year, that.year);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(day, month, year);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/Links.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/Links.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class Links {
+
+    @Field("self")
+    private String self;
+
+    @Field("statements")
+    private String statements;
+
+    public String getSelf() {
+        return self;
+    }
+
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+    public String getStatements() {
+        return statements;
+    }
+
+    public void setStatements(String statements) {
+        this.statements = statements;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/Links.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/Links.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.pscdataapi.models;
 
+import java.util.Objects;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 public class Links {
@@ -24,5 +25,35 @@ public class Links {
 
     public void setStatements(String statements) {
         this.statements = statements;
+    }
+
+    @Override
+    public String toString() {
+        return "Links{"
+                + "self='"
+                + self
+                + '\''
+                + ", statements='"
+                + statements
+                + '\''
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        Links links = (Links) object;
+        return Objects.equals(self, links.self)
+                && Objects.equals(statements, links.statements);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(self, statements);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/NameElements.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/NameElements.java
@@ -1,0 +1,89 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import java.util.Objects;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class NameElements {
+
+    @Field("title")
+    private String title;
+
+    @Field("forename")
+    private String forename;
+
+    @Field("surname")
+    private String surname;
+
+    @Field("middle_name")
+    private String middleName;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getForename() {
+        return forename;
+    }
+
+    public void setForename(String forename) {
+        this.forename = forename;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    @Override
+    public String toString() {
+        return "NameElements{"
+                + "title='"
+                + title
+                + '\''
+                + ", forename='"
+                + forename
+                + '\''
+                + ", surname='"
+                + surname
+                + '\''
+                + ", middleName='"
+                + middleName
+                + '\''
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        NameElements that = (NameElements) object;
+        return Objects.equals(title, that.title)
+                && Objects.equals(forename, that.forename)
+                && Objects.equals(surname, that.surname)
+                && Objects.equals(middleName, that.middleName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, forename, surname, middleName);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.companieshouse.api.psc.Address;
-import uk.gov.companieshouse.api.psc.ItemLinkTypes;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PscData {
@@ -55,7 +53,7 @@ public class PscData {
     private NameElements nameElements;
 
     @Field("links")
-    private List<ItemLinkTypes> links;
+    private Links links;
 
     public LocalDate getCeasedOn() {
         return ceasedOn;
@@ -141,11 +139,11 @@ public class PscData {
         this.nameElements = nameElements;
     }
 
-    public List<ItemLinkTypes> getLinks() {
+    public Links getLinks() {
         return links;
     }
 
-    public void setLinks(List<ItemLinkTypes> links) {
+    public void setLinks(Links links) {
         this.links = links;
     }
 

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
@@ -1,0 +1,261 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.companieshouse.api.psc.Address;
+import uk.gov.companieshouse.api.psc.ItemLinkTypes;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PscData {
+
+    @Field("ceased_on")
+    private LocalDate ceasedOn;
+
+    @Field("etag")
+    private String etag;
+
+    @Field("address")
+    private Address address;
+
+    @Field("name")
+    private String name;
+
+    @Field("nationality")
+    private String nationality;
+
+    @Field("country_of_residence")
+    private String countryOfResidence;
+
+    @Field("kind")
+    private String kind;
+
+    @Field("description")
+    private String description;
+
+    @Field("service_address_is_same_as_registered_office_address")
+    private Boolean serviceAddressIsSameAsRegisteredOfficeAddress;
+
+    @Field("residential_address_is_same_as_service_address")
+    private Boolean residentialAddressIsSameAsServiceAddress;
+
+    @Field("is_sanctioned")
+    private Boolean isSanctioned;
+
+    @Field("ceased")
+    private Boolean ceased;
+
+    @Field("natures_of_control")
+    private List<String> naturesOfControl;
+
+    @Field("name_elements")
+    private NameElements nameElements;
+
+    @Field("links")
+    private List<ItemLinkTypes> links;
+
+    public LocalDate getCeasedOn() {
+        return ceasedOn;
+    }
+
+    public void setCeasedOn(LocalDate ceasedOn) {
+        this.ceasedOn = ceasedOn;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNationality() {
+        return nationality;
+    }
+
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+
+    public String getCountryOfResidence() {
+        return countryOfResidence;
+    }
+
+    public void setCountryOfResidence(String countryOfResidence) {
+        this.countryOfResidence = countryOfResidence;
+    }
+
+    public Boolean getServiceAddressIsSameAsRegisteredOfficeAddress() {
+        return serviceAddressIsSameAsRegisteredOfficeAddress;
+    }
+
+    public void setServiceAddressIsSameAsRegisteredOfficeAddress(
+            Boolean serviceAddressIsSameAsRegisteredOfficeAddress) {
+        this.serviceAddressIsSameAsRegisteredOfficeAddress
+                = serviceAddressIsSameAsRegisteredOfficeAddress;
+    }
+
+    public Boolean getResidentialAddressIsSameAsServiceAddress() {
+        return residentialAddressIsSameAsServiceAddress;
+    }
+
+    public void setResidentialAddressIsSameAsServiceAddress(
+            Boolean residentialAddressIsSameAsServiceAddress) {
+        this.residentialAddressIsSameAsServiceAddress
+                = residentialAddressIsSameAsServiceAddress;
+    }
+
+    public List<String> getNaturesOfControl() {
+        return naturesOfControl;
+    }
+
+    public void setNaturesOfControl(List<String> naturesOfControl) {
+        this.naturesOfControl = naturesOfControl;
+    }
+
+    public NameElements getNameElements() {
+        return nameElements;
+    }
+
+    public void setNameElements(NameElements nameElements) {
+        this.nameElements = nameElements;
+    }
+
+    public List<ItemLinkTypes> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<ItemLinkTypes> links) {
+        this.links = links;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Boolean getSanctioned() {
+        return isSanctioned;
+    }
+
+    public void setSanctioned(Boolean sanctioned) {
+        isSanctioned = sanctioned;
+    }
+
+    public Boolean getCeased() {
+        return ceased;
+    }
+
+    public void setCeased(Boolean ceased) {
+        this.ceased = ceased;
+    }
+
+    @Override
+    public String toString() {
+        return "PscData{"
+                + "ceasedOn="
+                + ceasedOn
+                + ", etag='"
+                + etag
+                + '\''
+                + ", address="
+                + address
+                + ", name='"
+                + name
+                + '\''
+                + ", nationality='"
+                + nationality
+                + '\''
+                + ", countryOfResidence='"
+                + countryOfResidence
+                + '\''
+                + ", kind='"
+                + kind
+                + '\''
+                + ", description='"
+                + description
+                + '\''
+                + ", serviceAddressIsSameAsRegisteredOfficeAddress="
+                + serviceAddressIsSameAsRegisteredOfficeAddress
+                + ", residentialAddressIsSameAsServiceAddress="
+                + residentialAddressIsSameAsServiceAddress
+                + ", isSanctioned="
+                + isSanctioned
+                + ", ceased="
+                + ceased
+                + ", naturesOfControl="
+                + naturesOfControl
+                + ", nameElements="
+                + nameElements
+                + ", links="
+                + links
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        PscData pscData = (PscData) object;
+        return Objects.equals(ceasedOn, pscData.ceasedOn)
+                && Objects.equals(etag, pscData.etag)
+                && Objects.equals(address, pscData.address)
+                && Objects.equals(name, pscData.name)
+                && Objects.equals(nationality, pscData.nationality)
+                && Objects.equals(countryOfResidence, pscData.countryOfResidence)
+                && Objects.equals(kind, pscData.kind)
+                && Objects.equals(description, pscData.description)
+                && Objects.equals(serviceAddressIsSameAsRegisteredOfficeAddress,
+                pscData.serviceAddressIsSameAsRegisteredOfficeAddress)
+                && Objects.equals(residentialAddressIsSameAsServiceAddress,
+                pscData.residentialAddressIsSameAsServiceAddress)
+                && Objects.equals(isSanctioned, pscData.isSanctioned)
+                && Objects.equals(ceased, pscData.ceased)
+                && Objects.equals(naturesOfControl, pscData.naturesOfControl)
+                && Objects.equals(nameElements, pscData.nameElements)
+                && Objects.equals(links, pscData.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ceasedOn, etag, address, name, nationality, countryOfResidence,
+                kind, description, serviceAddressIsSameAsRegisteredOfficeAddress,
+                residentialAddressIsSameAsServiceAddress, isSanctioned, ceased, naturesOfControl,
+                nameElements, links);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscDocument.java
@@ -5,7 +5,6 @@ import java.util.Objects;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.companieshouse.api.psc.SensitiveData;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Document(collection = "delta_company_pscs")
@@ -39,7 +38,7 @@ public class PscDocument {
     private PscData data;
 
     @Field("sensitive_data")
-    private SensitiveData sensitiveData;
+    private PscSensitiveData sensitiveData;
 
     public String getId() {
         return id;
@@ -113,11 +112,11 @@ public class PscDocument {
         this.updatedBy = updatedBy;
     }
 
-    public SensitiveData getSensitiveData() {
+    public PscSensitiveData getSensitiveData() {
         return sensitiveData;
     }
 
-    public void setSensitiveData(SensitiveData sensitiveData) {
+    public void setSensitiveData(PscSensitiveData sensitiveData) {
         this.sensitiveData = sensitiveData;
     }
 

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscDocument.java
@@ -1,0 +1,182 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Objects;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.companieshouse.api.psc.SensitiveData;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Document(collection = "delta_company_pscs")
+public class PscDocument {
+
+    @Id
+    private String id;
+
+    @Field("psc_id")
+    private String pscId;
+
+    @Field("delta_at")
+    private String deltaAt;
+
+    @Field("notificaton_id")
+    private String notificationId;
+
+    @Field("company_number")
+    private String companyNumber;
+
+    @Field("updated_by")
+    private String updatedBy;
+
+    @Field("created")
+    private Created created;
+
+    @Field("updated")
+    private Updated updated;
+
+    @Field("data")
+    private PscData data;
+
+    @Field("sensitive_data")
+    private SensitiveData sensitiveData;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getPscId() {
+        return pscId;
+    }
+
+    public void setPscId(String pscId) {
+        this.pscId = pscId;
+    }
+
+    public String getDeltaAt() {
+        return deltaAt;
+    }
+
+    public void setDeltaAt(String deltaAt) {
+        this.deltaAt = deltaAt;
+    }
+
+    public String getNotificationId() {
+        return notificationId;
+    }
+
+    public void setNotificationId(String notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public Created getCreated() {
+        return created;
+    }
+
+    public void setCreated(Created created) {
+        this.created = created;
+    }
+
+    public Updated getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(Updated updated) {
+        this.updated = updated;
+    }
+
+    public PscData getData() {
+        return data;
+    }
+
+    public void setData(PscData data) {
+        this.data = data;
+    }
+
+    public String getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(String updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+
+    public SensitiveData getSensitiveData() {
+        return sensitiveData;
+    }
+
+    public void setSensitiveData(SensitiveData sensitiveData) {
+        this.sensitiveData = sensitiveData;
+    }
+
+    @Override
+    public String toString() {
+        return "PscDocument{"
+                + "id='"
+                + id
+                + '\''
+                + ", pscId='"
+                + pscId
+                + '\''
+                + ", deltaAt='"
+                + deltaAt
+                + '\''
+                + ", notificationId='"
+                + notificationId
+                + '\''
+                + ", companyNumber='"
+                + companyNumber
+                + '\''
+                + ", updatedBy='"
+                + updatedBy
+                + '\''
+                + ", created="
+                + created
+                + ", updated="
+                + updated
+                + ", data="
+                + data
+                + ", sensitiveData="
+                + sensitiveData
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        PscDocument that = (PscDocument) object;
+        return Objects.equals(id, that.id)
+                && Objects.equals(pscId, that.pscId)
+                && Objects.equals(deltaAt, that.deltaAt)
+                && Objects.equals(notificationId, that.notificationId)
+                && Objects.equals(companyNumber, that.companyNumber)
+                && Objects.equals(updatedBy, that.updatedBy)
+                && Objects.equals(created, that.created)
+                && Objects.equals(updated, that.updated)
+                && Objects.equals(data, that.data)
+                && Objects.equals(sensitiveData, that.sensitiveData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, pscId, deltaAt, notificationId, companyNumber,
+                updatedBy, created, updated, data, sensitiveData);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscSensitiveData.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscSensitiveData.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import java.util.Objects;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class PscSensitiveData {
+    @Field("usual_residential_address")
+    private Address usualResidentialAddress;
+    @Field("date_of_birth")
+    private DateOfBirth dateOfBirth;
+
+    public Address getUsualResidentialAddress() {
+        return usualResidentialAddress;
+    }
+
+    public void setUsualResidentialAddress(Address usualResidentialAddress) {
+        this.usualResidentialAddress = usualResidentialAddress;
+    }
+
+    public DateOfBirth getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(DateOfBirth dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    @Override
+    public String toString() {
+        return "PscSensitiveData{"
+                + "usualResidentialAddress="
+                + usualResidentialAddress
+                + ", dateOfBirth="
+                + dateOfBirth
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        PscSensitiveData that = (PscSensitiveData) object;
+        return Objects.equals(usualResidentialAddress, that.usualResidentialAddress)
+                && Objects.equals(dateOfBirth, that.dateOfBirth);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(usualResidentialAddress, dateOfBirth);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/Updated.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/Updated.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import java.time.LocalDate;
+
+public class Updated {
+
+    private LocalDate at;
+
+    public LocalDate getAt() {
+        return at;
+    }
+
+    public Updated setAt(LocalDate at) {
+        this.at = at;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.mongodb.repository.Query;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
 
 public interface CompanyPscRepository extends MongoRepository<PscDocument, String> {
-    @Query("{'_id': ?0, 'updated.at':{$gte : { \"$date\" : \"?1\" } }}")
+    @Query("{'_id': ?0, 'delta.at':{$gte : { \"$date\" : \"?1\" } }}")
     List<PscDocument> findUpdatedPsc(String notificationId, String at);
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.pscdataapi.repository;
+
+import java.util.List;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+
+public interface CompanyPscRepository extends MongoRepository<PscDocument, String> {
+    @Query("{'_id': ?0, 'updated.at':{$gte : { \"$date\" : \"?1\" } }}")
+    List<PscDocument> findUpdatedPsc(String notificationId, String at);
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateDeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateDeSerializer.java
@@ -10,12 +10,12 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.pscdataapi.PscDataApiApplication;
 import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
 
 public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
-    public static final String APPLICATION_NAME_SPACE = "psc-data-api";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            PscDataApiApplication.APPLICATION_NAME_SPACE);
 
     @Override
     public LocalDate deserialize(JsonParser jsonParser, DeserializationContext

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateDeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateDeSerializer.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.pscdataapi.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
+
+public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
+    public static final String APPLICATION_NAME_SPACE = "psc-data-api";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+
+    @Override
+    public LocalDate deserialize(JsonParser jsonParser, DeserializationContext
+            deserializationContext) {
+        try {
+            LOGGER.info("Deserialising dates");
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter
+                    .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            JsonNode jsonNode = jsonParser.readValueAsTree();
+            JsonNode dateNode = jsonNode.get("$date");
+
+            /** If textValue() returns a value we received a string of
+             * format yyyy-MM-dd'T'HH:mm:ss'Z
+             * and use dateTimeFormatter to return LocalDate.
+             * 
+             * Otherwise we received a long of milliseconds away
+             * from 01/01/1970 and need to return
+             * a LocalDate without dateTimeFormatter.
+             */
+            return dateNode.textValue() != null
+                    ? LocalDate.parse(dateNode.textValue(), dateTimeFormatter)
+                    : LocalDate.ofInstant(Instant.ofEpochMilli(dateNode.get("$numberLong")
+                    .asLong()), ZoneId.systemDefault());
+        } catch (Exception exception) {
+            LOGGER.error("Deserialization failed.", exception);
+            throw new BadRequestException(exception.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateSerializer.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.pscdataapi.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+    @Override
+    public void serialize(LocalDate localDate, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        if (localDate == null) {
+            jsonGenerator.writeNull();
+        } else {
+            DateTimeFormatter dateTimeFormatter =
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            String format = localDate.atStartOfDay().format(dateTimeFormatter);
+            jsonGenerator.writeRawValue("ISODate(\"" + format + "\")");
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -1,0 +1,98 @@
+package uk.gov.companieshouse.pscdataapi.service;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
+import uk.gov.companieshouse.pscdataapi.models.Created;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.repository.CompanyPscRepository;
+import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
+
+@Service
+public class CompanyPscService {
+
+    private static final String APPLICATION_NAME_SPACE = "psc-data-api";
+    private static final Logger logger = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
+
+    private final DateTimeFormatter dateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    @Autowired
+    private CompanyPscTransformer transformer;
+    @Autowired
+    private CompanyPscRepository repository;
+
+    /**
+     * Save or update a natural disqualification.
+     * @param contextId     Id used for chsKafkaCall.
+     * @param requestBody   Data to be saved.
+     */
+    public void insertPscRecord(String contextId, FullRecordCompanyPSCApi requestBody) {
+        String notificationId = requestBody.getExternalData().getNotificationId();
+        boolean isLatestRecord = isLatestRecord(notificationId, requestBody
+                .getInternalData().getDeltaAt());
+        if (isLatestRecord) {
+            PscDocument document = transformer.transformPsc(notificationId, requestBody);
+            save(contextId, notificationId, document);
+        } else {
+            logger.info("PSC not persisted as the record provided is not the latest record.");
+        }
+    }
+
+    private boolean isLatestRecord(String notificationId, OffsetDateTime deltaAt) {
+        String formattedDate = deltaAt.format(dateTimeFormatter);
+        List<PscDocument> pscDocuments = repository
+                .findUpdatedPsc(notificationId, formattedDate);
+        return pscDocuments.isEmpty();
+    }
+
+    /**
+     * Save or update the mongo record.
+     * @param contextId Chs kafka id.
+     * @param notificationId Mongo id.
+     * @param document  Transformed Data.
+     */
+    private void save(String contextId, String notificationId,
+                      PscDocument document) {
+        Created created = getCreatedFromCurrentRecord(notificationId);
+        if (created == null) {
+            document.setCreated(new Created().setAt(LocalDateTime.now()));
+        } else {
+            document.setCreated(created);
+        }
+
+        try {
+            repository.save(document);
+            logger.info(String.format(
+                    "Company PSC record is updated in MongoDb for context id: %s and id: %s",
+                    contextId, notificationId));
+        } catch (IllegalArgumentException illegalArgumentEx) {
+            throw new BadRequestException(illegalArgumentEx.getMessage());
+        }
+    }
+
+    /**
+     * Check whether we are updating a record and if so persist created time.
+     * @param notificationId Mongo Id.
+     * @return created if this is an update save the previous created to the new document.
+     */
+    private Created getCreatedFromCurrentRecord(String notificationId) {
+        Created created = new Created();
+        try {
+            Optional<PscDocument> doc = repository.findById(notificationId);
+            return doc.map(PscDocument::getCreated).orElse(null);
+        } catch (Exception exception) {
+            logger.error("exception thrown: " + exception.getMessage());
+        }
+        return created;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -4,12 +4,10 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
 import uk.gov.companieshouse.pscdataapi.models.Created;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
@@ -19,12 +17,11 @@ import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
 @Service
 public class CompanyPscService {
 
-    private static final String APPLICATION_NAME_SPACE = "psc-data-api";
-    private static final Logger logger = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
-
     private final DateTimeFormatter dateTimeFormatter =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+    @Autowired
+    private Logger logger;
     @Autowired
     private CompanyPscTransformer transformer;
     @Autowired
@@ -87,8 +84,7 @@ public class CompanyPscService {
     private Created getCreatedFromCurrentRecord(String notificationId) {
         Created created = new Created();
         try {
-            Optional<PscDocument> doc = repository.findById(notificationId);
-            return doc.map(PscDocument::getCreated).orElse(null);
+            return repository.findById(notificationId).map(PscDocument::getCreated).orElse(null);
         } catch (Exception exception) {
             logger.error("exception thrown: " + exception.getMessage());
         }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
@@ -1,0 +1,110 @@
+package uk.gov.companieshouse.pscdataapi.transform;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.pscdataapi.data.IndividualPscRoles;
+import uk.gov.companieshouse.pscdataapi.data.SecurePscRoles;
+import uk.gov.companieshouse.pscdataapi.exceptions.FailedToTransformException;
+import uk.gov.companieshouse.pscdataapi.models.Created;
+import uk.gov.companieshouse.pscdataapi.models.NameElements;
+import uk.gov.companieshouse.pscdataapi.models.PscData;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.Updated;
+
+
+@Component
+public class CompanyPscTransformer {
+
+    private final DateTimeFormatter dateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS");
+
+    private static final Logger logger = LoggerFactory.getLogger("psc-data-api");
+
+
+    /**
+     * Transform PSC.
+     * @param notificationId PSC Id.
+     * @param requestBody request payload.
+     * @return PSC mongo Document.
+     */
+    public PscDocument transformPsc(String notificationId, FullRecordCompanyPSCApi requestBody) {
+        PscDocument pscDocument = new PscDocument();
+
+        try {
+            pscDocument.setId(notificationId);
+            pscDocument.setNotificationId(notificationId);
+            pscDocument.setPscId(requestBody.getExternalData().getPscId());
+            pscDocument.setCompanyNumber(requestBody.getExternalData().getCompanyNumber());
+            OffsetDateTime deltaAt = requestBody.getInternalData().getDeltaAt();
+            pscDocument.setDeltaAt(dateTimeFormatter.format(deltaAt));
+            Created created = new Created();
+            created.setAt(LocalDateTime.parse(requestBody.getInternalData().getCreatedAt()));
+            Updated updated = new Updated();
+            updated.setAt(requestBody.getInternalData().getUpdatedAt());
+            pscDocument.setCreated(created);
+            pscDocument.setUpdatedBy(requestBody.getInternalData().getUpdatedBy());
+            pscDocument.setUpdated(updated);
+            pscDocument.setSensitiveData(requestBody.getExternalData().getSensitiveData());
+            manageDataFields(requestBody, pscDocument);
+        } catch (Exception exception) {
+            throw new FailedToTransformException(String.format(
+                    "Failed to transform API payload: %s", exception.getMessage()));
+        }
+
+        return pscDocument;
+    }
+
+    private void manageDataFields(FullRecordCompanyPSCApi requestBody, PscDocument pscDocument) {
+        PscData data = new PscData();
+
+        data.setAddress(requestBody.getExternalData().getData().getServiceAddress());
+        data.setCeasedOn(requestBody.getExternalData().getData().getCeasedOn());
+        data.setDescription(requestBody.getExternalData().getData().getDescription());
+        data.setEtag(requestBody.getExternalData().getData().getEtag());
+        data.setKind(requestBody.getExternalData().getData().getKind());
+        data.setLinks(requestBody.getExternalData().getData().getLinks());
+        data.setName(requestBody.getExternalData().getData().getName());
+        data.setNationality(requestBody.getExternalData().getData().getNationality());
+        data.setNaturesOfControl(requestBody.getExternalData().getData().getNaturesOfControl());
+        data.setResidentialAddressIsSameAsServiceAddress(requestBody.getExternalData()
+                    .getData().getResidentialAddressIsSameAsServiceAddress());
+        data.setSanctioned(requestBody.getExternalData().getData().getIsSanctioned());
+        data.setServiceAddressIsSameAsRegisteredOfficeAddress(requestBody.getExternalData()
+                    .getData().getServiceAddressSameAsRegisteredOfficeAddress());
+
+        String kind = requestBody.getExternalData().getData().getKind();
+
+        if (IndividualPscRoles.includes(kind)) {
+            handleIndividualFields(requestBody, data);
+        }
+        if (SecurePscRoles.includes(kind)) {
+            handleSecureFields(requestBody, data);
+        }
+        pscDocument.setData(data);
+    }
+
+    private void handleIndividualFields(FullRecordCompanyPSCApi requestBody, PscData data) {
+        createNameElements(requestBody, data);
+        data.setCountryOfResidence(requestBody.getExternalData().getData().getCountryOfResidence());
+    }
+
+    private void handleSecureFields(FullRecordCompanyPSCApi requestBody, PscData data) {
+        Boolean ceased = requestBody.getExternalData().getData().getCeasedOn() != null;
+        data.setCeased(ceased);
+    }
+
+    private void createNameElements(FullRecordCompanyPSCApi requestBody, PscData data) {
+        NameElements nameElements = new NameElements();
+        nameElements.setTitle(requestBody.getExternalData().getData().getTitle());
+        nameElements.setForename(requestBody.getExternalData().getData().getForename());
+        nameElements.setMiddleName(requestBody.getExternalData().getData().getOtherForenames());
+        nameElements.setSurname(requestBody.getExternalData().getData().getSurname());
+        data.setNameElements(nameElements);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/util/PscTransformationHelper.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/util/PscTransformationHelper.java
@@ -1,0 +1,61 @@
+package uk.gov.companieshouse.pscdataapi.util;
+
+import java.time.LocalDateTime;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.api.psc.ItemLinkTypes;
+import uk.gov.companieshouse.pscdataapi.models.Created;
+import uk.gov.companieshouse.pscdataapi.models.Links;
+import uk.gov.companieshouse.pscdataapi.models.NameElements;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.Updated;
+
+
+public class PscTransformationHelper {
+
+    private PscTransformationHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Creates the created and updated fields.
+     * @param requestBody request payload.
+     * @param pscDocument output document.
+     */
+    public static void createDateFields(FullRecordCompanyPSCApi requestBody,
+                                        PscDocument pscDocument) {
+        Created created = new Created();
+        created.setAt(LocalDateTime.parse(requestBody.getInternalData().getCreatedAt()));
+        Updated updated = new Updated();
+        updated.setAt(requestBody.getInternalData().getUpdatedAt());
+        pscDocument.setUpdated(updated);
+        pscDocument.setCreated(created);
+    }
+
+    /**
+     * Creates Links field.
+     * @param requestBody request payload.
+     * @return Links object.
+     */
+    public static Links createLinks(FullRecordCompanyPSCApi requestBody) {
+        Links links = new Links();
+        ItemLinkTypes itemLinkTypes = requestBody.getExternalData()
+                .getData().getLinks().get(0);
+        links.setSelf(itemLinkTypes.getSelf());
+        links.setStatements(itemLinkTypes.getStatements());
+        return links;
+    }
+
+    /**
+     * Creates NameElements field.
+     * @param requestBody request payload.
+     * @return NameElements object.
+     */
+    public static NameElements createNameElements(FullRecordCompanyPSCApi requestBody) {
+        NameElements nameElements = new NameElements();
+        nameElements.setTitle(requestBody.getExternalData().getData().getTitle());
+        nameElements.setForename(requestBody.getExternalData().getData().getForename());
+        nameElements.setMiddleName(requestBody.getExternalData().getData().getOtherForenames());
+        nameElements.setSurname(requestBody.getExternalData().getData().getSurname());
+        return nameElements;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
     mongodb:
       uri: ${MONGODB_URL:mongodb://mongo:27017}
       name: company_pscs
-      field-naming-strategy: org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy
   jackson:
     default-property-inclusion: NON_NULL
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+management:
+  endpoints:
+    web:
+      base-path: /psc-data-api
+      path-mapping:
+        health: /healthcheck
+
+logger:
+  namespace: psc-data-api
+
+spring:
+  data:
+    mongodb:
+      uri: ${MONGODB_URL:mongodb://mongo:27017}
+      name: company_pscs
+      field-naming-strategy: org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy
+  jackson:
+    default-property-inclusion: NON_NULL
+
+mongodb:
+  pscs:
+    collection:
+      name: delta_company_pscs

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
+
+class ApplicationConfigTest {
+    private ApplicationConfig applicationConfig;
+
+    @BeforeEach
+    void setUp() {
+        applicationConfig = new ApplicationConfig();
+    }
+    @Test
+    void mongoCustomConversions() {
+        assertThat(applicationConfig.mongoCustomConversions(), is(not(nullValue())));
+        assertThat(applicationConfig.mongoCustomConversions(), isA(MongoCustomConversions.class));
+    }
+
+    @Test
+    void offsetDateTimeGenerator() {
+        assertThat(applicationConfig.offsetDateTimeGenerator(), is(not(nullValue())));
+        assertThat(applicationConfig.offsetDateTimeGenerator(), isA(Supplier.class));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfigTest.java
@@ -1,0 +1,77 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.WebRequest;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@ExtendWith(MockitoExtension.class)
+class ExceptionHandlerConfigTest {
+    private ExceptionHandlerConfig exceptionHandlerConfigConfig;
+
+    @Mock
+    Logger logger;
+    @Mock
+    WebRequest request;
+
+    @BeforeEach
+    void setUp() {
+        exceptionHandlerConfigConfig = new ExceptionHandlerConfig(logger);
+    }
+
+    @Test
+    void handleException() {
+        ResponseEntity response = exceptionHandlerConfigConfig.handleException(new Exception("exception"), request);
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertThat(response, is(not(nullValue())));
+        assertThat(response.getStatusCode(), is(HttpStatus.INTERNAL_SERVER_ERROR));
+        assertThat(responseBody.get("message"), is("Unable to process the request."));
+    }
+
+    @Test
+    void handleNotFoundException() {
+        ResponseEntity response = exceptionHandlerConfigConfig.handleNotFoundException(new Exception("exception"), request);
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertThat(response, is(not(nullValue())));
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+        assertThat(responseBody.get("message"), is("Resource not found."));
+    }
+
+    @Test
+    void handleMethodNotAllowedException() {
+        ResponseEntity response = exceptionHandlerConfigConfig.handleMethodNotAllowedException(new Exception("exception"), request);
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertThat(response, is(not(nullValue())));
+        assertThat(response.getStatusCode(), is(HttpStatus.METHOD_NOT_ALLOWED));
+        assertThat(responseBody.get("message"), is("Unable to process the request."));
+    }
+
+    @Test
+    void handleServiceUnavailableException() {
+        ResponseEntity response = exceptionHandlerConfigConfig.handleServiceUnavailableException(new Exception("exception"), request);
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertThat(response, is(not(nullValue())));
+        assertThat(response.getStatusCode(), is(HttpStatus.SERVICE_UNAVAILABLE));
+        assertThat(responseBody.get("message"), is("Service unavailable."));
+    }
+
+    @Test
+    void handleBadRequestException() {
+        ResponseEntity response = exceptionHandlerConfigConfig.handleBadRequestException(new Exception("exception"), request);
+        Map<String, Object> responseBody = (Map<String, Object>) response.getBody();
+        assertThat(response, is(not(nullValue())));
+        assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+        assertThat(responseBody.get("message"), is("Bad request."));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/config/LoggingConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/config/LoggingConfigTest.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
+
+class LoggingConfigTest {
+
+    LoggingConfig loggingConfig;
+
+    @BeforeEach
+    void setUp() {
+        loggingConfig = new LoggingConfig();
+    }
+
+
+    @Test
+    void logger() {
+        assertThat(loggingConfig.logger(), is(not(nullValue())));
+        assertThat(loggingConfig.logger(), isA(Logger.class));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/config/MongoPscConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/config/MongoPscConfigTest.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.pscdataapi.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
+
+@ExtendWith(MockitoExtension.class)
+class MongoPscConfigTest {
+
+    @Mock
+    private MongoCustomConversions mongoCustomConversions;
+
+    private MongoPscConfig mongoConfig;
+
+    @BeforeEach
+    void setUp() {
+        mongoConfig = new MongoPscConfig();
+    }
+
+    @Test
+    void mongoMappingContext() {
+        assertThat(mongoConfig.mongoMappingContext(mongoCustomConversions), is(not(nullValue())));
+        assertThat(mongoConfig.mongoMappingContext(mongoCustomConversions), isA(MongoMappingContext.class));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscReadConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscReadConverterTest.java
@@ -5,8 +5,10 @@ import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.pscdataapi.exceptions.FailedToConvertException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 class CompanyPscReadConverterTest {
 
@@ -26,5 +28,11 @@ class CompanyPscReadConverterTest {
         FullRecordCompanyPSCApi pscApi = converter.convert(document);
 
         assertEquals(NOTIFICATION_ID, pscApi.getExternalData().getNotificationId());
+    }
+
+    @Test
+    void conversionFails() {
+        Document brokenDocument = new Document("unknown_property", "value");
+        assertThrows(FailedToConvertException.class, () -> converter.convert(brokenDocument));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscReadConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscReadConverterTest.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.pscdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+
+import static org.junit.Assert.assertEquals;
+
+class CompanyPscReadConverterTest {
+
+    private static final String NOTIFICATION_ID = "123456";
+
+    private CompanyPscReadConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new CompanyPscReadConverter(new ObjectMapper());
+    }
+
+    @Test
+    void canConvertDocument() {
+        Document notificationIdNode = new Document("notification_id", NOTIFICATION_ID);
+        Document document = new Document("external_data", notificationIdNode);
+        FullRecordCompanyPSCApi pscApi = converter.convert(document);
+
+        assertEquals(NOTIFICATION_ID, pscApi.getExternalData().getNotificationId());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscWriteConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscWriteConverterTest.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.pscdataapi.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.BasicDBObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+
+import static org.junit.Assert.assertTrue;
+
+class CompanyPscWriteConverterTest {
+
+    private static final String PSC_ID = "pscId";
+
+    private CompanyPscWriteConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new CompanyPscWriteConverter(new ObjectMapper());
+    }
+
+    @Test
+    void canConvertDocument() {
+        PscDocument document = new PscDocument();
+        document.setNotificationId(PSC_ID);
+
+        BasicDBObject object = converter.convert(document);
+
+        String json = object.toJson();
+        assertTrue(json.contains(PSC_ID));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscWriteConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/converter/CompanyPscWriteConverterTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
 
+import org.bson.Document;
+import uk.gov.companieshouse.pscdataapi.exceptions.FailedToConvertException;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 class CompanyPscWriteConverterTest {
@@ -28,5 +31,10 @@ class CompanyPscWriteConverterTest {
 
         String json = object.toJson();
         assertTrue(json.contains(PSC_ID));
+    }
+
+    @Test
+    void conversionFails() {
+        assertThrows(FailedToConvertException.class, () -> converter.convert(null));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRolesTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRolesTest.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.pscdataapi.data;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.Assert.assertEquals;
+
+class CorporatePscRolesTest {
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void includes(String role, boolean isMatch) {
+        assertEquals(CorporatePscRoles.includes(role), isMatch);
+    }
+
+    private static Stream<Arguments> provideParameters() {
+        return Stream.of(
+                Arguments.of("corporate-entity-person-with-significant-control", true),
+                Arguments.of("individual-incorrect-psc", false),
+                Arguments.of("corporate-entity-beneficial-owner", true),
+                Arguments.of("individual-person-significant-control", false),
+                Arguments.of("corporate-owner", false),
+                Arguments.of("corporate-entity-owner", false)
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRolesTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRolesTest.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.pscdataapi.data;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.Assert.assertEquals;
+
+class IndividualPscRolesTest {
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void includes(String role, boolean isMatch) {
+        assertEquals(IndividualPscRoles.includes(role), isMatch);
+    }
+
+    private static Stream<Arguments> provideParameters() {
+        return Stream.of(
+                Arguments.of("individual-person-with-significant-control", true),
+                Arguments.of("individual-incorrect-psc", false),
+                Arguments.of("corporate-entity-beneficial-owner", false),
+                Arguments.of("individual-person-significant-control", false),
+                Arguments.of("legal-person-person-with-significant-control", true),
+                Arguments.of("legal-person-with-significant-control", false)
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/data/SecurePscRolesTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/data/SecurePscRolesTest.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.pscdataapi.data;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.Assert.assertEquals;
+
+class SecurePscRolesTest {
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void includes(String role, boolean isMatch) {
+        assertEquals(SecurePscRoles.includes(role), isMatch);
+    }
+
+    private static Stream<Arguments> provideParameters() {
+        return Stream.of(
+                Arguments.of("super-secure-person-with-significant-control", true),
+                Arguments.of("individual-incorrect-psc", false),
+                Arguments.of("super-secure-beneficial-owner", true),
+                Arguments.of("individual-person-significant-control", false),
+                Arguments.of("corporate-owner", false),
+                Arguments.of("corporate-entity-owner", false)
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateSerializerTest.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.pscdataapi.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LocalDateSerializerTest {
+
+    private LocalDateSerializer serializer;
+
+    @Mock
+    private JsonGenerator generator;
+
+    @Captor
+    private ArgumentCaptor<String> dateString;
+
+    @BeforeEach
+    void setUp() {
+        serializer = new LocalDateSerializer();
+    }
+
+    @Test
+    void dateShouldSerialize() throws Exception {
+        LocalDate date = LocalDate.of(2020, 1, 1);
+
+        serializer.serialize(date, generator, null);
+
+        verify(generator).writeRawValue(dateString.capture());
+        assertEquals("ISODate(\"2020-01-01T00:00:00.000Z\")", dateString.getValue());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
@@ -1,0 +1,95 @@
+package uk.gov.companieshouse.pscdataapi.service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.psc.ExternalData;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.api.psc.InternalData;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.Updated;
+import uk.gov.companieshouse.pscdataapi.repository.CompanyPscRepository;
+import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CompanyPscServiceTest {
+
+    private static final String PSC_ID = "pscId";
+
+    @Mock
+    private CompanyPscRepository repository;
+
+    @Mock
+    private CompanyPscTransformer transformer;
+
+    @Captor
+    private ArgumentCaptor<String> dateCaptor;
+
+    @InjectMocks
+    private CompanyPscService service;
+
+    private FullRecordCompanyPSCApi request;
+    private PscDocument document;
+    private String dateString;
+
+    @BeforeEach
+    public void setUp() {
+        OffsetDateTime date = OffsetDateTime.now();
+        request = new FullRecordCompanyPSCApi();
+        InternalData internal = new InternalData();
+        ExternalData external = new ExternalData();
+        external.setNotificationId(PSC_ID);
+        internal.setDeltaAt(date);
+        request.setInternalData(internal);
+        request.setExternalData(external);
+        document = new PscDocument();
+        document.setUpdated(new Updated().setAt(LocalDate.now()));
+        final DateTimeFormatter dateTimeFormatter =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        dateString = date.format(dateTimeFormatter);
+    }
+
+    @Test
+    void insertPscRecordSavesPsc() {
+        when(repository.findUpdatedPsc(eq(PSC_ID), dateCaptor.capture())).thenReturn(new ArrayList<>());
+        when(repository.findById(PSC_ID)).thenReturn(Optional.empty());
+        when(transformer.transformPsc(PSC_ID, request)).thenReturn(document);
+
+        service.insertPscRecord("", request);
+
+        verify(repository).save(document);
+        assertEquals(dateString, dateCaptor.getValue());
+        assertNotNull(document.getCreated().getAt());
+    }
+
+    @Test
+    void insertPscRecordDoesNotSavePscWhenUpdateAlreadyMade() {
+
+        List<PscDocument> documents = new ArrayList<>();
+        documents.add(new PscDocument());
+        when(repository.findUpdatedPsc(eq(PSC_ID), dateCaptor.capture())).thenReturn(documents);
+
+        service.insertPscRecord("", request);
+
+        verify(repository, times(0)).save(document);
+        assertEquals(dateString, dateCaptor.getValue());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.psc.ExternalData;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.api.psc.InternalData;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
 import uk.gov.companieshouse.pscdataapi.models.Updated;
 import uk.gov.companieshouse.pscdataapi.repository.CompanyPscRepository;
@@ -33,6 +34,9 @@ import static org.mockito.Mockito.when;
 class CompanyPscServiceTest {
 
     private static final String PSC_ID = "pscId";
+
+    @Mock
+    private Logger logger;
 
     @Mock
     private CompanyPscRepository repository;

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformerTest.java
@@ -1,0 +1,96 @@
+package uk.gov.companieshouse.pscdataapi.transform;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.psc.Data;
+import uk.gov.companieshouse.api.psc.DateOfBirth;
+import uk.gov.companieshouse.api.psc.ExternalData;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.api.psc.InternalData;
+import uk.gov.companieshouse.api.psc.SensitiveData;
+import uk.gov.companieshouse.pscdataapi.exceptions.FailedToTransformException;
+import uk.gov.companieshouse.pscdataapi.models.NameElements;
+import uk.gov.companieshouse.pscdataapi.models.PscData;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.Updated;
+import uk.gov.companieshouse.pscdataapi.util.TestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(MockitoExtension.class)
+class CompanyPscTransformerTest {
+
+    private static final String INDIVIDUAL_KIND = "individual-person-with-significant-control";
+    private static final String SECURE_KIND = "super-secure-person-with-significant-control";
+    private static final String CORPORATE_KIND = "corporate-entity-person-with-significant-control";
+
+    private CompanyPscTransformer pscTransformer = new CompanyPscTransformer();
+    private FullRecordCompanyPSCApi fullRecordCompanyPSCApi;
+
+    @Test
+    void testIndividualPscIsTransformedSuccessfully() throws FailedToTransformException {
+        // given
+        fullRecordCompanyPSCApi = TestHelper.buildFullRecordPsc(INDIVIDUAL_KIND);
+        PscDocument expectedDocument = TestHelper.buildPscDocument(INDIVIDUAL_KIND);
+        // when
+        PscDocument result = pscTransformer.transformPsc("pscId", fullRecordCompanyPSCApi);
+
+        // then
+        assertThat(result.getData(), is(expectedDocument.getData()));
+        assertThat(result.getData().getNameElements().getSurname(),
+                is(expectedDocument.getData().getNameElements().getSurname()));
+        assertThat(result.getDeltaAt(), is(expectedDocument.getDeltaAt()));
+        assertThat(result.getUpdated().getAt(), is(expectedDocument.getUpdated().getAt()));
+        assertThat(result.getUpdatedBy(), is(expectedDocument.getUpdatedBy()));
+    }
+
+    @Test
+    void testCorporatePscIsTransformedSuccessfully() throws FailedToTransformException {
+        // given
+        fullRecordCompanyPSCApi = TestHelper.buildFullRecordPsc(CORPORATE_KIND);
+        PscDocument expectedDocument = TestHelper.buildPscDocument(CORPORATE_KIND);
+        // when
+        PscDocument result = pscTransformer.transformPsc("pscId", fullRecordCompanyPSCApi);
+
+        // then
+        assertThat(result.getData(), is(expectedDocument.getData()));
+        assertThat(result.getDeltaAt(), is(expectedDocument.getDeltaAt()));
+        assertThat(result.getUpdated().getAt(), is(expectedDocument.getUpdated().getAt()));
+        assertThat(result.getUpdatedBy(), is(expectedDocument.getUpdatedBy()));
+    }
+
+    @Test
+    void testSecurePscIsTransformedSuccessfully() throws FailedToTransformException {
+        // given
+        fullRecordCompanyPSCApi = TestHelper.buildFullRecordPsc(SECURE_KIND);
+        PscDocument expectedDocument = TestHelper.buildPscDocument(SECURE_KIND);
+        // when
+        PscDocument result = pscTransformer.transformPsc("pscId", fullRecordCompanyPSCApi);
+
+        // then
+        assertThat(result.getData(), is(expectedDocument.getData()));
+        assertThat(result.getData().getCeased(), is(expectedDocument.getData().getCeased()));
+        assertThat(result.getDeltaAt(), is(expectedDocument.getDeltaAt()));
+        assertThat(result.getUpdated().getAt(), is(expectedDocument.getUpdated().getAt()));
+        assertThat(result.getUpdatedBy(), is(expectedDocument.getUpdatedBy()));
+    }
+
+    @Test
+    void testApiThrowsExceptionWhenTransformFails() {
+        FullRecordCompanyPSCApi api = new FullRecordCompanyPSCApi();
+        try {
+            pscTransformer.transformPsc("id", api);
+            Assert.fail("Expected a FailedToTransformException to be thrown");
+        } catch (FailedToTransformException e) {
+            assert(e.getMessage().contains("Failed to transform API payload:"));
+        }
+    }
+
+
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformerTest.java
@@ -1,22 +1,15 @@
 package uk.gov.companieshouse.pscdataapi.transform;
 
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.psc.Data;
-import uk.gov.companieshouse.api.psc.DateOfBirth;
-import uk.gov.companieshouse.api.psc.ExternalData;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
-import uk.gov.companieshouse.api.psc.InternalData;
-import uk.gov.companieshouse.api.psc.SensitiveData;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscdataapi.exceptions.FailedToTransformException;
-import uk.gov.companieshouse.pscdataapi.models.NameElements;
-import uk.gov.companieshouse.pscdataapi.models.PscData;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
-import uk.gov.companieshouse.pscdataapi.models.Updated;
 import uk.gov.companieshouse.pscdataapi.util.TestHelper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,11 +18,15 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(MockitoExtension.class)
 class CompanyPscTransformerTest {
 
+    @Mock
+    private Logger logger;
+
     private static final String INDIVIDUAL_KIND = "individual-person-with-significant-control";
     private static final String SECURE_KIND = "super-secure-person-with-significant-control";
     private static final String CORPORATE_KIND = "corporate-entity-person-with-significant-control";
 
-    private CompanyPscTransformer pscTransformer = new CompanyPscTransformer();
+    @InjectMocks
+    private CompanyPscTransformer pscTransformer;
     private FullRecordCompanyPSCApi fullRecordCompanyPSCApi;
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
@@ -1,0 +1,79 @@
+package uk.gov.companieshouse.pscdataapi.util;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import uk.gov.companieshouse.api.psc.Data;
+import uk.gov.companieshouse.api.psc.DateOfBirth;
+import uk.gov.companieshouse.api.psc.ExternalData;
+import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
+import uk.gov.companieshouse.api.psc.InternalData;
+import uk.gov.companieshouse.api.psc.SensitiveData;
+import uk.gov.companieshouse.pscdataapi.models.NameElements;
+import uk.gov.companieshouse.pscdataapi.models.PscData;
+import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.Updated;
+
+public class TestHelper {
+
+    public static FullRecordCompanyPSCApi buildFullRecordPsc(String kind) {
+        FullRecordCompanyPSCApi output  = new FullRecordCompanyPSCApi();
+
+        ExternalData externalData = new ExternalData();
+        Data data = new Data();
+        data.setName("forename");
+        data.setCompanyNumber("companyNumber");
+        data.setKind(kind);
+        SensitiveData sensitiveData = new SensitiveData();
+        sensitiveData.setDateOfBirth(new DateOfBirth());
+        externalData.setData(data);
+        externalData.setSensitiveData(sensitiveData);
+        externalData.setNotificationId("id");
+        externalData.setCompanyNumber("companyNumber");
+        externalData.setPscId("pscId");
+        InternalData internalData = new InternalData();
+        internalData.setDeltaAt(OffsetDateTime.parse("2022-01-12T00:00:00Z"));
+        internalData.setCreatedAt("2022-01-12T00:00:00");
+        internalData.setUpdatedAt(LocalDate.parse("2022-01-12"));
+
+        if(kind.contains("individual")) {
+            data.setSurname("surname");
+        } else if(kind.contains("secure")) {
+            data.setCeasedOn(LocalDate.now());
+        }
+
+        output.setExternalData(externalData);
+        output.setInternalData(internalData);
+        return output;
+    }
+
+    public static PscDocument buildPscDocument(String kind) {
+        PscDocument output = new PscDocument();
+
+        PscData data = new PscData();
+        data.setKind(kind);
+        data.setName("forename");
+        SensitiveData sensitiveData = new SensitiveData();
+        sensitiveData.setDateOfBirth(new DateOfBirth());
+
+        output.setNotificationId("id");
+        output.setData(data);
+        output.setSensitiveData(sensitiveData);
+        output.setPscId("pscId");
+        output.setCompanyNumber("1234567");
+        output.setDeltaAt("20220112000000000000");
+        Updated updated = new Updated();
+        updated.setAt(LocalDate.parse("2022-01-12"));
+        output.setUpdated(updated);
+
+        if(kind.contains("individual")) {
+            NameElements nameElements = new NameElements();
+            nameElements.setSurname("surname");
+            data.setNameElements(nameElements);
+        } else if(kind.contains("secure")) {
+            data.setCeasedOn(LocalDate.now());
+            data.setCeased(true);
+        }
+
+        return output;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
@@ -2,15 +2,22 @@ package uk.gov.companieshouse.pscdataapi.util;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.List;
+
 import uk.gov.companieshouse.api.psc.Data;
-import uk.gov.companieshouse.api.psc.DateOfBirth;
 import uk.gov.companieshouse.api.psc.ExternalData;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.api.psc.InternalData;
+import uk.gov.companieshouse.api.psc.ItemLinkTypes;
 import uk.gov.companieshouse.api.psc.SensitiveData;
+import uk.gov.companieshouse.api.psc.UsualResidentialAddress;
+import uk.gov.companieshouse.pscdataapi.models.Address;
+import uk.gov.companieshouse.pscdataapi.models.DateOfBirth;
+import uk.gov.companieshouse.pscdataapi.models.Links;
 import uk.gov.companieshouse.pscdataapi.models.NameElements;
 import uk.gov.companieshouse.pscdataapi.models.PscData;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.PscSensitiveData;
 import uk.gov.companieshouse.pscdataapi.models.Updated;
 
 public class TestHelper {
@@ -23,8 +30,10 @@ public class TestHelper {
         data.setName("forename");
         data.setCompanyNumber("companyNumber");
         data.setKind(kind);
+        data.setLinks(List.of(new ItemLinkTypes()));
+        data.setServiceAddress(new uk.gov.companieshouse.api.psc.Address());
         SensitiveData sensitiveData = new SensitiveData();
-        sensitiveData.setDateOfBirth(new DateOfBirth());
+        sensitiveData.setDateOfBirth(new uk.gov.companieshouse.api.psc.DateOfBirth());
         externalData.setData(data);
         externalData.setSensitiveData(sensitiveData);
         externalData.setNotificationId("id");
@@ -36,6 +45,8 @@ public class TestHelper {
         internalData.setUpdatedAt(LocalDate.parse("2022-01-12"));
 
         if(kind.contains("individual")) {
+            UsualResidentialAddress address = new UsualResidentialAddress();
+            sensitiveData.setUsualResidentialAddress(address);
             data.setSurname("surname");
         } else if(kind.contains("secure")) {
             data.setCeasedOn(LocalDate.now());
@@ -52,12 +63,11 @@ public class TestHelper {
         PscData data = new PscData();
         data.setKind(kind);
         data.setName("forename");
-        SensitiveData sensitiveData = new SensitiveData();
-        sensitiveData.setDateOfBirth(new DateOfBirth());
+        data.setLinks(new Links());
+        data.setAddress(new Address());
 
         output.setNotificationId("id");
         output.setData(data);
-        output.setSensitiveData(sensitiveData);
         output.setPscId("pscId");
         output.setCompanyNumber("1234567");
         output.setDeltaAt("20220112000000000000");
@@ -66,6 +76,10 @@ public class TestHelper {
         output.setUpdated(updated);
 
         if(kind.contains("individual")) {
+            PscSensitiveData sensitiveData = new PscSensitiveData();
+            sensitiveData.setDateOfBirth(new DateOfBirth());
+            sensitiveData.setUsualResidentialAddress(new Address());
+            output.setSensitiveData(sensitiveData);
             NameElements nameElements = new NameElements();
             nameElements.setSurname("surname");
             data.setNameElements(nameElements);


### PR DESCRIPTION
This PR adds a rest controller for the PUT endpoint, a service for handling submissions to the endpoint including transforming into the mongodb object and saving to the db. Additionally, application configs and mongo configs have been added as well as read/write converters and date serialisers.

**Resolves:**
- DSND-1631