### PR TITLE
edited transformer so legal types don't require sensitive data block

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRoles.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRoles.java
@@ -5,7 +5,9 @@ import java.util.stream.Stream;
 
 public enum CorporatePscRoles {
     CORPORATE_PSC("corporate-entity-person-with-significant-control"),
-    CORPORATE_BO("corporate-entity-beneficial-owner");
+    CORPORATE_BO("corporate-entity-beneficial-owner"),
+    LEGAL_PSC("legal-person-person-with-significant-control"),
+    LEGAL_BO("legal-person-beneficial-owner");
 
     private String role;
 

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRoles.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRoles.java
@@ -5,9 +5,7 @@ import java.util.stream.Stream;
 
 public enum IndividualPscRoles {
     INDIVIDUAL_PSC("individual-person-with-significant-control"),
-    LEGAL_PSC("legal-person-person-with-significant-control"),
-    INDIVIDUAL_BO("individual-beneficial-owner"),
-    LEGAL_BO("legal-person-beneficial-owner");
+    INDIVIDUAL_BO("individual-beneficial-owner");
 
     private String role;
 

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
@@ -37,9 +37,6 @@ public class PscData {
     @Field("service_address_is_same_as_registered_office_address")
     private Boolean serviceAddressIsSameAsRegisteredOfficeAddress;
 
-    @Field("residential_address_is_same_as_service_address")
-    private Boolean residentialAddressIsSameAsServiceAddress;
-
     @Field("is_sanctioned")
     private Boolean isSanctioned;
 
@@ -111,16 +108,6 @@ public class PscData {
             Boolean serviceAddressIsSameAsRegisteredOfficeAddress) {
         this.serviceAddressIsSameAsRegisteredOfficeAddress
                 = serviceAddressIsSameAsRegisteredOfficeAddress;
-    }
-
-    public Boolean getResidentialAddressIsSameAsServiceAddress() {
-        return residentialAddressIsSameAsServiceAddress;
-    }
-
-    public void setResidentialAddressIsSameAsServiceAddress(
-            Boolean residentialAddressIsSameAsServiceAddress) {
-        this.residentialAddressIsSameAsServiceAddress
-                = residentialAddressIsSameAsServiceAddress;
     }
 
     public List<String> getNaturesOfControl() {
@@ -206,8 +193,6 @@ public class PscData {
                 + '\''
                 + ", serviceAddressIsSameAsRegisteredOfficeAddress="
                 + serviceAddressIsSameAsRegisteredOfficeAddress
-                + ", residentialAddressIsSameAsServiceAddress="
-                + residentialAddressIsSameAsServiceAddress
                 + ", isSanctioned="
                 + isSanctioned
                 + ", ceased="
@@ -240,8 +225,6 @@ public class PscData {
                 && Objects.equals(description, pscData.description)
                 && Objects.equals(serviceAddressIsSameAsRegisteredOfficeAddress,
                 pscData.serviceAddressIsSameAsRegisteredOfficeAddress)
-                && Objects.equals(residentialAddressIsSameAsServiceAddress,
-                pscData.residentialAddressIsSameAsServiceAddress)
                 && Objects.equals(isSanctioned, pscData.isSanctioned)
                 && Objects.equals(ceased, pscData.ceased)
                 && Objects.equals(naturesOfControl, pscData.naturesOfControl)
@@ -253,7 +236,7 @@ public class PscData {
     public int hashCode() {
         return Objects.hash(ceasedOn, etag, address, name, nationality, countryOfResidence,
                 kind, description, serviceAddressIsSameAsRegisteredOfficeAddress,
-                residentialAddressIsSameAsServiceAddress, isSanctioned, ceased, naturesOfControl,
+                isSanctioned, ceased, naturesOfControl,
                 nameElements, links);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscSensitiveData.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscSensitiveData.java
@@ -8,6 +8,8 @@ public class PscSensitiveData {
     private Address usualResidentialAddress;
     @Field("date_of_birth")
     private DateOfBirth dateOfBirth;
+    @Field("residential_address_is_same_as_service_address")
+    private Boolean residentialAddressIsSameAsServiceAddress;
 
     public Address getUsualResidentialAddress() {
         return usualResidentialAddress;
@@ -25,6 +27,16 @@ public class PscSensitiveData {
         this.dateOfBirth = dateOfBirth;
     }
 
+    public Boolean getResidentialAddressIsSameAsServiceAddress() {
+        return residentialAddressIsSameAsServiceAddress;
+    }
+
+    public void setResidentialAddressIsSameAsServiceAddress(
+            Boolean residentialAddressIsSameAsServiceAddress) {
+        this.residentialAddressIsSameAsServiceAddress
+                = residentialAddressIsSameAsServiceAddress;
+    }
+
     @Override
     public String toString() {
         return "PscSensitiveData{"
@@ -32,6 +44,8 @@ public class PscSensitiveData {
                 + usualResidentialAddress
                 + ", dateOfBirth="
                 + dateOfBirth
+                + ", residentialAddressIsSameAsServiceAddress="
+                + residentialAddressIsSameAsServiceAddress
                 + '}';
     }
 
@@ -45,11 +59,14 @@ public class PscSensitiveData {
         }
         PscSensitiveData that = (PscSensitiveData) object;
         return Objects.equals(usualResidentialAddress, that.usualResidentialAddress)
-                && Objects.equals(dateOfBirth, that.dateOfBirth);
+                && Objects.equals(dateOfBirth, that.dateOfBirth)
+                && Objects.equals(residentialAddressIsSameAsServiceAddress,
+                that.residentialAddressIsSameAsServiceAddress);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(usualResidentialAddress, dateOfBirth);
+        return Objects.hash(usualResidentialAddress, dateOfBirth,
+                residentialAddressIsSameAsServiceAddress);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/util/PscTransformationHelper.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/util/PscTransformationHelper.java
@@ -17,21 +17,6 @@ public class PscTransformationHelper {
     }
 
     /**
-     * Creates the created and updated fields.
-     * @param requestBody request payload.
-     * @param pscDocument output document.
-     */
-    public static void createDateFields(FullRecordCompanyPSCApi requestBody,
-                                        PscDocument pscDocument) {
-        Created created = new Created();
-        created.setAt(LocalDateTime.parse(requestBody.getInternalData().getCreatedAt()));
-        Updated updated = new Updated();
-        updated.setAt(requestBody.getInternalData().getUpdatedAt());
-        pscDocument.setUpdated(updated);
-        pscDocument.setCreated(created);
-    }
-
-    /**
      * Creates Links field.
      * @param requestBody request payload.
      * @return Links object.

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRolesTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/data/CorporatePscRolesTest.java
@@ -22,7 +22,9 @@ class CorporatePscRolesTest {
                 Arguments.of("corporate-entity-beneficial-owner", true),
                 Arguments.of("individual-person-significant-control", false),
                 Arguments.of("corporate-owner", false),
-                Arguments.of("corporate-entity-owner", false)
+                Arguments.of("corporate-entity-owner", false),
+                Arguments.of("legal-person-with-significant-control", false),
+                Arguments.of("legal-person-person-with-significant-control", true)
         );
     }
 

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRolesTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/data/IndividualPscRolesTest.java
@@ -21,7 +21,7 @@ class IndividualPscRolesTest {
                 Arguments.of("individual-incorrect-psc", false),
                 Arguments.of("corporate-entity-beneficial-owner", false),
                 Arguments.of("individual-person-significant-control", false),
-                Arguments.of("legal-person-person-with-significant-control", true),
+                Arguments.of("legal-person-person-with-significant-control", false),
                 Arguments.of("legal-person-with-significant-control", false)
         );
     }

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
@@ -44,7 +44,6 @@ public class TestHelper {
         externalData.setPscId("pscId");
         InternalData internalData = new InternalData();
         internalData.setDeltaAt(OffsetDateTime.parse("2022-01-12T00:00:00Z"));
-        internalData.setCreatedAt("2022-01-12T00:00:00");
         internalData.setUpdatedAt(LocalDate.parse("2022-01-12"));
 
         if(kind.contains("individual")) {
@@ -70,7 +69,9 @@ public class TestHelper {
         data.setKind(kind);
         data.setName("forename");
         data.setLinks(new Links());
-        data.setAddress(new Address());
+        if (!kind.contains("secure")) {
+            data.setAddress(new Address());
+        }
 
         output.setNotificationId("id");
         output.setData(data);
@@ -78,7 +79,7 @@ public class TestHelper {
         output.setCompanyNumber("1234567");
         output.setDeltaAt("20220112000000000000");
         Updated updated = new Updated();
-        updated.setAt(LocalDate.parse("2022-01-12"));
+        updated.setAt(LocalDate.now());
         output.setUpdated(updated);
 
         if(kind.contains("individual")) {


### PR DESCRIPTION
Changed code so that legal pscs and BO types no longer have their sensitive data set as these types won't have any sensitive data in the delta. Also moved residentialAddressIsSameAsServiceAddress from PscData to PscSensitiveData.

Required for:

- DSND-1503