### PR TITLE
DSND-1632: added a call to resource-changed endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <environmentVariables>
+                        <CHS_API_KEY>key</CHS_API_KEY>
+                        <API_URL>key</API_URL>
+                        <PAYMENTS_API_URL>key</PAYMENTS_API_URL>
+                    </environmentVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -21,7 +21,7 @@ public class ChsKafkaApiService {
     InternalApiClient internalApiClient;
     @Value("${chs.api.kafka.url}")
     private String chsKafkaApiUrl;
-    @Value("${chs.api.kafka.uri}")
+    @Value("${chs.api.kafka.resource-changed.uri}")
     private String resourceChangedUri;
     private static final String PSC_URI = "/company/%s/persons-with-significant-control/"
                                           + "%s/full_record";

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -1,0 +1,73 @@
+package uk.gov.companieshouse.pscdataapi.api;
+
+import java.time.OffsetDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.pscdataapi.util.PscTransformationHelper;
+
+@Service
+public class ChsKafkaApiService {
+    @Autowired
+    InternalApiClient internalApiClient;
+    @Value("${chs.api.kafka.url}")
+    private String chsKafkaApiUrl;
+    @Value("${chs.api.kafka.uri}")
+    private String resourceChangedUri;
+    private static final String PSC_URI = "/company/%s/persons-with-significant-control/"
+                                          + "%s/full_record";
+    private static final String CHANGED_EVENT_TYPE = "changed";
+    @Autowired
+    private Logger logger;
+
+    /**
+     * Creates a ChangedResource object to send a request to the chs kafka api.
+     *
+     * @param contextId chs kafka id
+     * @param companyNumber company number of psc
+     * @param notificationId mongo id
+     * @return passes request to api response handling
+     */
+    public ApiResponse<Void> invokeChsKafkaApi(String contextId, String companyNumber,
+                                               String notificationId, String kind) {
+        internalApiClient.setBasePath(chsKafkaApiUrl);
+        PrivateChangedResourcePost changedResourcePost = internalApiClient
+                .privateChangedResourceHandler().postChangedResource(resourceChangedUri,
+                        mapChangedResource(contextId, companyNumber, notificationId, kind));
+        return handleApiCall(changedResourcePost);
+    }
+
+    private ChangedResource mapChangedResource(String contextId, String companyNumber,
+                                               String notificationId, String kind) {
+        ChangedResourceEvent event = new ChangedResourceEvent();
+        ChangedResource changedResource = new ChangedResource();
+        event.setPublishedAt(String.valueOf(OffsetDateTime.now()));
+        event.setType(CHANGED_EVENT_TYPE);
+        changedResource.setResourceUri(String.format(PSC_URI, companyNumber, notificationId));
+        changedResource.event(event);
+        changedResource.setResourceKind(PscTransformationHelper.mapResourceKind(kind));
+        changedResource.setContextId(contextId);
+        return changedResource;
+    }
+
+    private ApiResponse<Void> handleApiCall(PrivateChangedResourcePost changedResourcePost) {
+        try {
+            return changedResourcePost.execute();
+        } catch (ApiErrorResponseException exception) {
+            logger.error("Unsuccessful call to /resource-changed endpoint", exception);
+            throw new ServiceUnavailableException(exception.getMessage());
+        } catch (RuntimeException exception) {
+            logger.error("Error occurred while calling /resource-changed endpoint", exception);
+            throw exception;
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfig.java
@@ -13,10 +13,12 @@ import java.util.function.Supplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.pscdataapi.converter.CompanyPscReadConverter;
 import uk.gov.companieshouse.pscdataapi.converter.CompanyPscWriteConverter;
 import uk.gov.companieshouse.pscdataapi.serialization.LocalDateDeSerializer;
 import uk.gov.companieshouse.pscdataapi.serialization.LocalDateSerializer;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @Configuration
 public class ApplicationConfig {
@@ -31,6 +33,11 @@ public class ApplicationConfig {
         ObjectMapper objectMapper = mongoDbObjectMapper();
         return new MongoCustomConversions(List.of(new CompanyPscWriteConverter(objectMapper),
                 new CompanyPscReadConverter(objectMapper)));
+    }
+
+    @Bean
+    public InternalApiClient internalApiClient() {
+        return ApiSdkManager.getPrivateSDK();
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.pscdataapi.config;
 
+import com.mongodb.MongoException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
@@ -98,7 +99,8 @@ public class ExceptionHandlerConfig {
     * @param request request.
     * @return error response to return.
     */
-    @ExceptionHandler(value = {ServiceUnavailableException.class, DataAccessException.class})
+    @ExceptionHandler(value = {ServiceUnavailableException.class,
+            DataAccessException.class, MongoException.class})
     public ResponseEntity<Object> handleServiceUnavailableException(Exception ex,
                                                                     WebRequest request) {
         logger.error(String.format("Service unavailable, response code: %s",

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -42,14 +42,14 @@ public class CompanyPscService {
     @Transactional
     public void insertPscRecord(String contextId, FullRecordCompanyPSCApi requestBody) {
         String notificationId = requestBody.getExternalData().getNotificationId();
-        String kind = requestBody.getExternalData().getData().getKind();
         boolean isLatestRecord = isLatestRecord(notificationId, requestBody
                 .getInternalData().getDeltaAt());
-        String companyNumber = requestBody.getExternalData().getCompanyNumber();
         if (isLatestRecord) {
             PscDocument document = transformer.transformPsc(notificationId, requestBody);
             save(contextId, notificationId, document);
-            chsKafkaApiService.invokeChsKafkaApi(contextId, companyNumber, notificationId, kind);
+            chsKafkaApiService.invokeChsKafkaApi(contextId,
+                    requestBody.getExternalData().getCompanyNumber(),
+                    notificationId, requestBody.getExternalData().getData().getKind());
 
         } else {
             logger.info("PSC not persisted as the record provided is not the latest record.");

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -6,8 +6,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscdataapi.api.ChsKafkaApiService;
 import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
 import uk.gov.companieshouse.pscdataapi.models.Created;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
@@ -26,19 +29,28 @@ public class CompanyPscService {
     private CompanyPscTransformer transformer;
     @Autowired
     private CompanyPscRepository repository;
+    @Autowired
+    ChsKafkaApiService chsKafkaApiService;
+    @Autowired
+    InternalApiClient internalApiClient;
 
     /**
      * Save or update a natural disqualification.
      * @param contextId     Id used for chsKafkaCall.
      * @param requestBody   Data to be saved.
      */
+    @Transactional
     public void insertPscRecord(String contextId, FullRecordCompanyPSCApi requestBody) {
         String notificationId = requestBody.getExternalData().getNotificationId();
+        String kind = requestBody.getExternalData().getData().getKind();
         boolean isLatestRecord = isLatestRecord(notificationId, requestBody
                 .getInternalData().getDeltaAt());
+        String companyNumber = requestBody.getExternalData().getCompanyNumber();
         if (isLatestRecord) {
             PscDocument document = transformer.transformPsc(notificationId, requestBody);
             save(contextId, notificationId, document);
+            chsKafkaApiService.invokeChsKafkaApi(contextId, companyNumber, notificationId, kind);
+
         } else {
             logger.info("PSC not persisted as the record provided is not the latest record.");
         }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/util/PscTransformationHelper.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/util/PscTransformationHelper.java
@@ -1,13 +1,8 @@
 package uk.gov.companieshouse.pscdataapi.util;
 
-import java.time.LocalDateTime;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.api.psc.ItemLinkTypes;
-import uk.gov.companieshouse.pscdataapi.models.Created;
 import uk.gov.companieshouse.pscdataapi.models.Links;
-import uk.gov.companieshouse.pscdataapi.models.NameElements;
-import uk.gov.companieshouse.pscdataapi.models.PscDocument;
-import uk.gov.companieshouse.pscdataapi.models.Updated;
 
 
 public class PscTransformationHelper {
@@ -28,5 +23,38 @@ public class PscTransformationHelper {
         links.setSelf(itemLinkTypes.getSelf());
         links.setStatements(itemLinkTypes.getStatements());
         return links;
+    }
+
+    /**
+     * Maps kind from FullRecordCompanyPSCApi object to a valid resource kind for Chs kafka api.
+     * @param kind psc kind
+     * @return String containing valid resource kind
+     */
+    public static String mapResourceKind(String kind) {
+        String validResourceKind = new String();
+
+        switch (kind) {
+            case "individual-person-with-significant-control":
+                validResourceKind = "company-psc-individual";
+                break;
+            case "corporate-entity-person-with-significant-control":
+                validResourceKind = "company-psc-corporate";
+                break;
+            case "legal-person-person-with-significant-control":
+                validResourceKind = "company-psc-legal";
+                break;
+            case "super-secure-person-with-significant-control":
+                validResourceKind = "company-psc-supersecure";
+                break;
+            case "individual-beneficial-owner":
+            case "corporate-entity-beneficial-owner":
+            case "legal-person-beneficial-owner":
+            case "super-secure-beneficial-owner":
+                validResourceKind = kind;
+                break;
+            default:
+        }
+
+        return validResourceKind;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ management:
       path-mapping:
         health: /healthcheck
 
+chs:
+  api:
+    kafka:
+      url: ${CHS_KAFKA_API_URL:localhost}
+      uri: ${PSC_API_RESOURCE_CHANGED_URI:/private/resource-changed}
+
 logger:
   namespace: psc-data-api
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,8 @@ chs:
   api:
     kafka:
       url: ${CHS_KAFKA_API_URL:localhost}
-      uri: ${PSC_API_RESOURCE_CHANGED_URI:/private/resource-changed}
+      resource-changed:
+        uri: ${PSC_API_RESOURCE_CHANGED_URI:/private/resource-changed}
 
 logger:
   namespace: psc-data-api

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -66,7 +66,7 @@ public class ChsKafkaApiServiceTest {
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
-        Assertions.assertThat(changedResourceCaptor.getValue()).isNotNull();
+        Assertions.assertThat(changedResourceCaptor.getValue().getEvent().getType()).isEqualTo("changed");
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -7,11 +7,14 @@ import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
@@ -42,6 +45,9 @@ public class ChsKafkaApiServiceTest {
     @InjectMocks
     private ChsKafkaApiService chsKafkaApiService;
 
+    @Captor
+    ArgumentCaptor<ChangedResource> changedResourceCaptor;
+
     @BeforeEach
     void setUp() {
         testHelper = new TestHelper();
@@ -58,8 +64,9 @@ public class ChsKafkaApiServiceTest {
         Assertions.assertThat(apiResponse).isNotNull();
 
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
+        Assertions.assertThat(changedResourceCaptor.getValue()).isNotNull();
     }
 
     @Test
@@ -73,8 +80,9 @@ public class ChsKafkaApiServiceTest {
                 TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID, "kind"));
 
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
+        Assertions.assertThat(changedResourceCaptor.getValue()).isNotNull();
     }
 
     @Test
@@ -88,7 +96,8 @@ public class ChsKafkaApiServiceTest {
                 TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID, "kind"));
 
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
-        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
+        Assertions.assertThat(changedResourceCaptor.getValue()).isNotNull();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -1,0 +1,94 @@
+package uk.gov.companieshouse.pscdataapi.api;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
+import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
+import uk.gov.companieshouse.pscdataapi.util.TestHelper;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ChsKafkaApiServiceTest {
+
+    @Mock
+    private Logger logger;
+    @Mock
+    InternalApiClient internalApiClient;
+    @Mock
+    PrivateChangedResourceHandler privateChangedResourceHandler;
+    @Mock
+    private PrivateChangedResourcePost privateChangedResourcePost;
+    @Mock
+    private ApiResponse<Void> response;
+
+    private TestHelper testHelper;
+    @InjectMocks
+    private ChsKafkaApiService chsKafkaApiService;
+
+    @BeforeEach
+    void setUp() {
+        testHelper = new TestHelper();
+    }
+
+    @Test
+    void invokeChsKafkaEndpoint() throws ApiErrorResponseException {
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
+        when(privateChangedResourcePost.execute()).thenReturn(response);
+
+        ApiResponse<?> apiResponse = chsKafkaApiService.invokeChsKafkaApi(
+                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID, "kind");
+        Assertions.assertThat(apiResponse).isNotNull();
+
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(privateChangedResourcePost, times(1)).execute();
+    }
+
+    @Test
+    void invokeChsKafkaEndpointThrowsApiErrorException() throws ApiErrorResponseException {
+        ApiErrorResponseException exception = new ApiErrorResponseException(new HttpResponseException.Builder(408, "Test Request timeout", new HttpHeaders()));
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
+        when(privateChangedResourcePost.execute()).thenThrow(exception);
+
+        Assert.assertThrows(ServiceUnavailableException.class, () -> chsKafkaApiService.invokeChsKafkaApi(
+                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID, "kind"));
+
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(privateChangedResourcePost, times(1)).execute();
+    }
+
+    @Test
+    void invokeChsKafkaEndpointThrowsRuntimeException() throws ApiErrorResponseException {
+        RuntimeException exception = new RuntimeException("Test Runtime exception");
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
+        when(privateChangedResourcePost.execute()).thenThrow(exception);
+
+        Assert.assertThrows(RuntimeException.class, () -> chsKafkaApiService.invokeChsKafkaApi(
+                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID, "kind"));
+
+        verify(internalApiClient, times(1)).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
+        verify(privateChangedResourcePost, times(1)).execute();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -82,7 +82,7 @@ public class ChsKafkaApiServiceTest {
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
-        Assertions.assertThat(changedResourceCaptor.getValue()).isNotNull();
+        Assertions.assertThat(changedResourceCaptor.getValue().getEvent().getType()).isEqualTo("changed");
     }
 
     @Test
@@ -98,6 +98,6 @@ public class ChsKafkaApiServiceTest {
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
-        Assertions.assertThat(changedResourceCaptor.getValue()).isNotNull();
+        Assertions.assertThat(changedResourceCaptor.getValue().getEvent().getType()).isEqualTo("changed");
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
@@ -4,6 +4,9 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.InternalApiClient;
+
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -21,6 +24,12 @@ class ApplicationConfigTest {
     void mongoCustomConversions() {
         assertThat(applicationConfig.mongoCustomConversions(), is(not(nullValue())));
         assertThat(applicationConfig.mongoCustomConversions(), isA(MongoCustomConversions.class));
+    }
+
+    @Test
+    void internalApiClient() {
+        assertThat(applicationConfig.internalApiClient(), is(not(nullValue())));
+        assertThat(applicationConfig.internalApiClient(), isA(InternalApiClient.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
@@ -14,10 +14,12 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.psc.Data;
 import uk.gov.companieshouse.api.psc.ExternalData;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.api.psc.InternalData;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscdataapi.api.ChsKafkaApiService;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
 import uk.gov.companieshouse.pscdataapi.models.Updated;
 import uk.gov.companieshouse.pscdataapi.repository.CompanyPscRepository;
@@ -43,6 +45,8 @@ class CompanyPscServiceTest {
 
     @Mock
     private CompanyPscTransformer transformer;
+    @Mock
+    private ChsKafkaApiService chsKafkaApiService;
 
     @Captor
     private ArgumentCaptor<String> dateCaptor;
@@ -60,7 +64,10 @@ class CompanyPscServiceTest {
         request = new FullRecordCompanyPSCApi();
         InternalData internal = new InternalData();
         ExternalData external = new ExternalData();
+        Data data = new Data();
         external.setNotificationId(PSC_ID);
+        external.setData(data);
+        data.setKind("kind");
         internal.setDeltaAt(date);
         request.setInternalData(internal);
         request.setExternalData(external);

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/transform/PscTransformationHelperTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/transform/PscTransformationHelperTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.pscdataapi.transform;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.pscdataapi.util.PscTransformationHelper;
+import uk.gov.companieshouse.pscdataapi.util.TestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+
+public class PscTransformationHelperTest {
+
+    @Test
+    void testIndividualPscResourceKindIsMappedCorrectly() {
+        //when
+        String validKind = PscTransformationHelper.mapResourceKind(TestHelper.INDIVIDUAL_KIND);
+        //then
+        assertEquals(validKind, "company-psc-individual");
+    }
+    @Test
+    void testSecurePscResourceKindIsMappedCorrectly() {
+        //when
+        String validKind = PscTransformationHelper.mapResourceKind(TestHelper.SECURE_KIND);
+        //then
+        assertThat(validKind, is("company-psc-supersecure"));
+    }
+    @Test
+    void testCorporatePscResourceKindIsMappedCorrectly() {
+        //when
+        String validKind = PscTransformationHelper.mapResourceKind(TestHelper.CORPORATE_KIND);
+        //then
+        assertThat(validKind, is("company-psc-corporate"));
+    }
+    @Test
+    void testLegalPscResourceKindIsMappedCorrectly() {
+        //when
+        String validKind = PscTransformationHelper.mapResourceKind(TestHelper.LEGAL_KIND);
+        //then
+        assertThat(validKind, is("company-psc-legal"));
+    }
+    @Test
+    void testIndividualBOResourceKindIsMappedCorrectly() {
+        //when
+        String validKind = PscTransformationHelper.mapResourceKind(TestHelper.INDIVIDUAL_BO_KIND);
+        //then
+        assertThat(validKind, is(TestHelper.INDIVIDUAL_BO_KIND));
+    }
+    @Test
+    void testIndividualBOResourceKindIsNotMappedToAnythingElse() {
+        //when
+        String validKind = PscTransformationHelper.mapResourceKind(TestHelper.INDIVIDUAL_BO_KIND);
+        //then
+        assertThat(validKind, is(not(TestHelper.INDIVIDUAL_KIND)));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
@@ -25,6 +25,11 @@ import uk.gov.companieshouse.pscdataapi.models.Updated;
 
 public class TestHelper {
 
+    public static final String COMPANY_NUMBER = "companyNumber";
+    public static final String NOTIFICATION_ID = "notificationId";
+    public static final String X_REQUEST_ID = "654321";
+
+
     public static FullRecordCompanyPSCApi buildFullRecordPsc(String kind) {
         FullRecordCompanyPSCApi output  = new FullRecordCompanyPSCApi();
 

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
@@ -24,7 +24,11 @@ import uk.gov.companieshouse.pscdataapi.models.PscSensitiveData;
 import uk.gov.companieshouse.pscdataapi.models.Updated;
 
 public class TestHelper {
-
+    public static final String INDIVIDUAL_KIND = "individual-person-with-significant-control";
+    public static final String SECURE_KIND = "super-secure-person-with-significant-control";
+    public static final String CORPORATE_KIND = "corporate-entity-person-with-significant-control";
+    public static final String LEGAL_KIND = "legal-person-person-with-significant-control";
+    public static final String INDIVIDUAL_BO_KIND = "individual-beneficial-owner";
     public static final String COMPANY_NUMBER = "companyNumber";
     public static final String NOTIFICATION_ID = "notificationId";
     public static final String X_REQUEST_ID = "654321";


### PR DESCRIPTION
Added a call to resource changed endpoint once data is added to mongo to communicate with chs-kafka-api. The ChsKafkaApiService (which sends the ChangedResource request to chs-kafka-api) was added, along with the corresponding unit tests. Other unit tests were also updated. 
Finally, transactional model was implemented for the database (@Transactional annotation was added).

Required for:
- DSND-1632