### PR TITLE
DSND-2703: Upgrade to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,6 @@
         <data-sync-api-sdk-java.version>1.0.6</data-sync-api-sdk-java.version>
         <api-security-java.version>2.0.4</api-security-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
-        <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
-        <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
 
         <!-- tests -->
         <jib-maven-plugin.version>3.4.3</jib-maven-plugin.version>
@@ -107,22 +105,23 @@
                     <groupId>com.github.docker-java</groupId>
                     <artifactId>docker-java-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-helper-java</artifactId>
-            <version>${api-helper-java-library.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -157,6 +156,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.4</version>
+        <version>2.1.5</version>
         <relativePath />
     </parent>
     <artifactId>psc-data-api</artifactId>
@@ -14,37 +14,33 @@
     <name>psc-data-api</name>
     <description>Service handling CRUD functions for pscs</description>
     <properties>
-        <java.version>11</java.version>
+        <java.version>21</java.version>
         <start-class>uk.gov.companieshouse.pscdataapi.PscDataApiApplication</start-class>
-        <spring-boot-dependencies.version>2.6.4</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>2.6.4</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.3.1</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.3.1</spring-boot-maven-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-        <jib-maven-plugin.version>3.3.0</jib-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-        <ch-kafka.version>1.4.2</ch-kafka.version>
-        <kafka-models.version>1.0.34</kafka-models.version>
+        <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>
+        <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <ch-kafka.version>3.0.2</ch-kafka.version>
+        <kafka-models.version>3.0.7</kafka-models.version>
 
         <!-- Internal -->
-        <structured-logging.version>1.9.25</structured-logging.version>
-        <private-api-sdk-java.version>2.0.347</private-api-sdk-java.version>
-        <data-sync-api-sdk-java.version>1.0.4</data-sync-api-sdk-java.version>
-        <api-security-java.version>0.4.1</api-security-java.version>
-        <api-sdk-manager-java-library.version>1.0.8</api-sdk-manager-java-library.version>
-        <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
-        <sdk-manager-java.version>1.5.17</sdk-manager-java.version>
+        <structured-logging.version>3.0.8</structured-logging.version>
+        <private-api-sdk-java.version>4.0.160</private-api-sdk-java.version>
+        <data-sync-api-sdk-java.version>1.0.6</data-sync-api-sdk-java.version>
+        <api-security-java.version>2.0.4</api-security-java.version>
+        <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
+        <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
+        <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
 
         <!-- tests -->
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-        <jib-maven-plugin.version>3.3.0</jib-maven-plugin.version>
-        <io-cucumber.version>7.2.3</io-cucumber.version>
-        <test-containers.version>1.16.3</test-containers.version>
-        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
-        <assertj-core.version>3.22.0</assertj-core.version>
+        <jib-maven-plugin.version>3.4.3</jib-maven-plugin.version>
+        <io-cucumber.version>7.18.0</io-cucumber.version>
+        <test-containers.version>1.19.8</test-containers.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
-        <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
 
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,7 @@
         <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-        <ch-kafka.version>3.0.2</ch-kafka.version>
-        <kafka-models.version>3.0.7</kafka-models.version>
+<!--        <ch-kafka.version>3.0.2</ch-kafka.version>-->
 
         <!-- Internal -->
         <structured-logging.version>3.0.8</structured-logging.version>
@@ -88,11 +87,6 @@
                     <artifactId>log4j-to-slf4j</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>ch-kafka</artifactId>
-            <version>${ch-kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
         <!-- Internal -->
         <structured-logging.version>3.0.8</structured-logging.version>
-        <private-api-sdk-java.version>2.0.420</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.162</private-api-sdk-java.version>
         <data-sync-api-sdk-java.version>1.0.6</data-sync-api-sdk-java.version>
         <api-security-java.version>2.0.4</api-security-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
@@ -68,11 +68,6 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-api</artifactId>
-            <version>3.3.6</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
@@ -111,14 +106,10 @@
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-sdk-manager-java-library</artifactId>
-            <version>${api-sdk-manager-java-library.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
             <artifactId>data-sync-api-sdk-java</artifactId>
             <version>${data-sync-api-sdk-java.version}</version>
             <exclusions>
+                <!-- Exclusion due to transitive dependency being an older version-->
                 <exclusion>
                     <groupId>com.github.docker-java</groupId>
                     <artifactId>docker-java-api</artifactId>
@@ -173,11 +164,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>kafka-models</artifactId>
-            <version>${kafka-models.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <version>3.3.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
@@ -113,6 +118,12 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>data-sync-api-sdk-java</artifactId>
             <version>${data-sync-api-sdk-java.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.docker-java</groupId>
+                    <artifactId>docker-java-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
         <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-<!--        <ch-kafka.version>3.0.2</ch-kafka.version>-->
 
         <!-- Internal -->
         <structured-logging.version>3.0.8</structured-logging.version>

--- a/src/itest/java/uk/gov/companieshouse/pscdataapi/steps/PscDataSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/pscdataapi/steps/PscDataSteps.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.pscdataapi.steps;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.http.HttpStatusCodes;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.And;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.companieshouse.pscdataapi.config.AbstractMongoConfig.mongoDBContainer;
 
 import org.springframework.util.FileCopyUtils;
+import org.springframework.web.client.ResourceAccessException;
 import uk.gov.companieshouse.api.api.CompanyMetricsApiService;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.psc.*;
@@ -235,10 +237,10 @@ public class PscDataSteps {
         headers.set("ERIC-Authorised-Key-Roles", "*");
 
         HttpEntity<String> request = new HttpEntity<>(null, headers);
-        String uri = "/company/{company_number}/persons-with-significant-control/{notfication_id}/full_record";
-        ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.DELETE, request, Void.class, companyNumber, NOTIFICATION_ID);
+        String uri = "/company/%s/persons-with-significant-control/%s/full_record".formatted(companyNumber, NOTIFICATION_ID);
+        ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.DELETE, request, Void.class);
 
-        CucumberContext.CONTEXT.set("statusCode", response.getStatusCodeValue());
+        CucumberContext.CONTEXT.set("statusCode", response.getStatusCode().value());
     }
 
     @Given("a PSC does not exist for {string}")

--- a/src/itest/java/uk/gov/companieshouse/pscdataapi/steps/PscDataSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/pscdataapi/steps/PscDataSteps.java
@@ -94,18 +94,21 @@ public class PscDataSteps {
     private final String NOTIFICATION_ID = "ZfTs9WeeqpXTqf6dc6FZ4C0H0ZZ";
     private final String contextId = "5234234234";
 
+    private AutoCloseable autoCloseable;
+
     @Before
     public void dbCleanUp() {
         if (!mongoDBContainer.isRunning()) {
             mongoDBContainer.start();
         }
         companyPscRepository.deleteAll();
-        MockitoAnnotations.openMocks(this);
+        autoCloseable = MockitoAnnotations.openMocks(this);
     }
 
     @After
-    public void dbStop() {
+    public void dbStop() throws Exception {
         mongoDBContainer.stop();
+        autoCloseable.close();
     }
 
     @Given("Psc data api service is running")

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.api.psc.CorporateEntity;
 import uk.gov.companieshouse.api.psc.CorporateEntityBeneficialOwner;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
@@ -27,6 +26,7 @@ import uk.gov.companieshouse.api.psc.SuperSecureBeneficialOwner;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
+import uk.gov.companieshouse.pscdataapi.exceptions.ResourceNotFoundException;
 import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.pscdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscdataapi.service.CompanyPscService;
@@ -44,10 +44,11 @@ public class CompanyPscController {
 
     /**
      * PUT endpoint for PSC record
+     *
      * @param contextId contextId taken from header.
-     * @param request request payload.
+     * @param request   request payload.
      * @return response.
-     * */
+     */
     @PutMapping(path = "/{notification_id}/full_record", consumes = "application/json")
     public ResponseEntity<Void> submitPscData(@RequestHeader("x-request-id") String contextId,
                                               @RequestBody final FullRecordCompanyPSCApi request) {
@@ -62,7 +63,7 @@ public class CompanyPscController {
                 request.getExternalData().getCompanyNumber()), DataMapHolder.getLogMap());
         try {
             pscService.insertPscRecord(contextId, request);
-            LOGGER.infoContext(contextId,"Successfully inserted PSC",
+            LOGGER.infoContext(contextId, "Successfully inserted PSC",
                     DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.CREATED).build();
         } catch (ServiceUnavailableException ex) {
@@ -76,6 +77,7 @@ public class CompanyPscController {
 
     /**
      * Delete the data object for a company profile number.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -105,6 +107,7 @@ public class CompanyPscController {
 
     /**
      * Get the data object for a company profile number for Individual PSC.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -121,7 +124,7 @@ public class CompanyPscController {
                 DataMapHolder.getLogMap());
         try {
             Individual individual = pscService
-                    .getIndividualPsc(companyNumber , notificationId , registerView);
+                    .getIndividualPsc(companyNumber, notificationId, registerView);
             return new ResponseEntity<>(individual, HttpStatus.OK);
         } catch (ResourceNotFoundException ex) {
             LOGGER.error(ex.getMessage(), DataMapHolder.getLogMap());
@@ -134,6 +137,7 @@ public class CompanyPscController {
 
     /**
      * Get the data object for a company profile number for Individual Beneficial Owner PSC.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -164,6 +168,7 @@ public class CompanyPscController {
 
     /**
      * Get the data object for a company profile number for Corporate Entity PSC.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -191,6 +196,7 @@ public class CompanyPscController {
 
     /**
      * Get the data object for a company profile number for Corporate Entity Beneficial Owner PSC.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -246,6 +252,7 @@ public class CompanyPscController {
 
     /**
      * Get the data object for a company profile number for Legal Person Beneficial Owner PSC.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -273,6 +280,7 @@ public class CompanyPscController {
 
     /**
      * Get the data object for a company profile number for Super Secure PSC.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -300,6 +308,7 @@ public class CompanyPscController {
 
     /**
      * Get the data object for a company profile number for Super Secure Beneficial Owner PSC.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */
@@ -327,6 +336,7 @@ public class CompanyPscController {
 
     /**
      * Get the PSC List Summary for a company profile number.
+     *
      * @param companyNumber The number of the company
      * @return ResponseEntity
      */

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.pscdataapi.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class ResourceNotFoundException extends ResponseStatusException {
+    public ResourceNotFoundException(HttpStatus status, String message) {
+        super(status, message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/interceptor/RequestLoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/interceptor/RequestLoggingInterceptor.java
@@ -2,10 +2,10 @@ package uk.gov.companieshouse.pscdataapi.interceptor;
 
 import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
 import java.util.UUID;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.logging.Logger;

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.api.CompanyMetricsApiService;
-import uk.gov.companieshouse.api.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.RegisterApi;
 import uk.gov.companieshouse.api.metrics.RegistersApi;
@@ -34,6 +33,7 @@ import uk.gov.companieshouse.api.psc.SuperSecureBeneficialOwner;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscdataapi.api.ChsKafkaApiService;
 import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
+import uk.gov.companieshouse.pscdataapi.exceptions.ResourceNotFoundException;
 import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.pscdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscdataapi.models.Created;


### PR DESCRIPTION
This PR upgrades this service to Java 21, upgrades dependencies, and clears out unnecessary dependencies from the pom.

To get Docker working with Testcontainers, we had to exclude the `docker-java-api` dependency from the `data-sync-api-sdk-java` as the docker dep was not up to date and, therefore, incompatible with the most recent version of Spring/Testcontainers. This can be fixed by either explicitly adding the docker dep to the pom with the most recent version, or by excluding it from the offending dependency.

After this, the `TestRestTemplate` was not working when testing a `503` response when Mongo was down. TestRestTemplate was timing out before Mongo had a chance to timeout, and therefore throwing an exception rather than returning `503`. This, again, was due to a transitive dependency being out of date and overriding the more recent version. To fix this, we identified `api-sdk-manager-java-library` as the dependency that brought in the out of date transitive dep, so we removed this dependency entirely as it was not used in the service.

[DSND-2703](https://companieshouse.atlassian.net/browse/DSND-2703)

[DSND-2703]: https://companieshouse.atlassian.net/browse/DSND-2703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ