### PR TITLE
DSND-2801: Fix null fields on response and kafka message

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -95,7 +95,7 @@ public class ChsKafkaApiService {
         if (isDelete) {
             event.setType(DELETE_EVENT_TYPE);
 
-            ObjectMapper secondObjectMapper = new ObjectMapper()
+            ObjectMapper objectMapper = new ObjectMapper()
                     .registerModule(new JavaTimeModule())
                     .setDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
                     .setSerializationInclusion(JsonInclude.Include.NON_NULL)
@@ -103,8 +103,9 @@ public class ChsKafkaApiService {
                     .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
             try {
-                String pscDataAsString = secondObjectMapper.writeValueAsString(pscData);
-                Object pscDataAsObject = secondObjectMapper.readValue(pscDataAsString, Object.class);
+                Object pscDataAsObject = objectMapper.readValue(
+                        objectMapper.writeValueAsString(pscData),
+                        Object.class);
                 changedResource.setDeletedData(pscDataAsObject);
             } catch (JsonProcessingException ex) {
                 throw new SerDesException("Failed to serialise/deserialise psc data", ex);

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -1,12 +1,7 @@
 package uk.gov.companieshouse.pscdataapi.api;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,15 +28,17 @@ public class ChsKafkaApiService {
 
     private final InternalApiClient internalApiClient;
     private final Logger logger;
+    private final ObjectMapper objectMapper;
 
     @Value("${chs.api.kafka.url}")
     private String chsKafkaApiUrl;
     @Value("${chs.api.kafka.resource-changed.uri}")
     private String resourceChangedUri;
 
-    public ChsKafkaApiService(InternalApiClient internalApiClient, Logger logger) {
+    public ChsKafkaApiService(InternalApiClient internalApiClient, Logger logger, ObjectMapper objectMapper) {
         this.internalApiClient = internalApiClient;
         this.logger = logger;
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -94,14 +91,6 @@ public class ChsKafkaApiService {
         event.setPublishedAt(String.valueOf(OffsetDateTime.now()));
         if (isDelete) {
             event.setType(DELETE_EVENT_TYPE);
-
-            ObjectMapper objectMapper = new ObjectMapper()
-                    .registerModule(new JavaTimeModule())
-                    .setDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
-                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                    .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-
             try {
                 Object pscDataAsObject = objectMapper.readValue(
                         objectMapper.writeValueAsString(pscData),

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -92,6 +92,7 @@ public class ChsKafkaApiService {
         if (isDelete) {
             event.setType(DELETE_EVENT_TYPE);
             try {
+                // This write value/read value is necessary to remove null fields during the jackson conversion
                 Object pscDataAsObject = objectMapper.readValue(
                         objectMapper.writeValueAsString(pscData),
                         Object.class);

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfig.java
@@ -32,8 +32,7 @@ public class ApplicationConfig {
      * @return MongoCustomConversions.
      */
     @Bean
-    public MongoCustomConversions mongoCustomConversions() {
-        ObjectMapper objectMapper = mongoDbObjectMapper();
+    public MongoCustomConversions mongoCustomConversions(ObjectMapper objectMapper) {
         return new MongoCustomConversions(List.of(new CompanyPscWriteConverter(objectMapper),
                 new CompanyPscSensitiveWriteConverter(objectMapper),
                 new CompanyPscReadConverter(objectMapper, PscData.class),
@@ -52,13 +51,13 @@ public class ApplicationConfig {
     }
 
 
-
     /**
      * Mongo DB Object Mapper.
      *
      * @return ObjectMapper.
      */
-    private ObjectMapper mongoDbObjectMapper() {
+    @Bean
+    public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/ExceptionHandlerConfig.java
@@ -17,6 +17,7 @@ import org.springframework.web.context.request.WebRequest;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscdataapi.exceptions.BadRequestException;
 import uk.gov.companieshouse.pscdataapi.exceptions.MethodNotAllowedException;
+import uk.gov.companieshouse.pscdataapi.exceptions.SerDesException;
 import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
 
 @ControllerAdvice
@@ -34,12 +35,12 @@ public class ExceptionHandlerConfig {
 
     /**
      * Runtime exception handler. Acts as the catch-all scenario.
-    *
-    * @param ex      exception to handle.
-    * @param request request.
-    * @return error response to return.
-    */
-    @ExceptionHandler(value = {Exception.class})
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
+    @ExceptionHandler(value = {Exception.class, SerDesException.class})
     public ResponseEntity<Object> handleException(Exception ex, WebRequest request) {
         logger.error(String.format("Unexpected exception, response code: %s",
                 HttpStatus.INTERNAL_SERVER_ERROR), ex);
@@ -53,11 +54,11 @@ public class ExceptionHandlerConfig {
 
     /**
      * IllegalArgumentException exception handler.
-    *
-    * @param ex      exception to handle.
-    * @param request request.
-    * @return error response to return.
-    */
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
     @ExceptionHandler(value = {IllegalArgumentException.class})
     public ResponseEntity<Object> handleNotFoundException(Exception ex, WebRequest request) {
         logger.error(String.format("Resource not found, response code: %s",
@@ -72,11 +73,11 @@ public class ExceptionHandlerConfig {
 
     /**
      * MethodNotAllowedException exception handler.
-    *
-    * @param ex      exception to handle.
-    * @param request request.
-    * @return error response to return.
-    */
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
     @ExceptionHandler(value = {MethodNotAllowedException.class,
             HttpRequestMethodNotSupportedException.class})
     public ResponseEntity<Object> handleMethodNotAllowedException(
@@ -93,12 +94,12 @@ public class ExceptionHandlerConfig {
 
     /**
      * ServiceUnavailableException exception handler.
-    * To be thrown when there are connection issues.
-    *
-    * @param ex      exception to handle.
-    * @param request request.
-    * @return error response to return.
-    */
+     * To be thrown when there are connection issues.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
     @ExceptionHandler(value = {ServiceUnavailableException.class,
             DataAccessException.class, MongoException.class})
     public ResponseEntity<Object> handleServiceUnavailableException(Exception ex,
@@ -115,12 +116,12 @@ public class ExceptionHandlerConfig {
 
     /**
      * BadRequestException exception handler.
-    * Thrown when data is given in the wrong format.
-    *
-    * @param ex      exception to handle.
-    * @param request request.
-    * @return error response to return.
-    */
+     * Thrown when data is given in the wrong format.
+     *
+     * @param ex      exception to handle.
+     * @param request request.
+     * @return error response to return.
+     */
     @ExceptionHandler(value = {BadRequestException.class, DateTimeParseException.class,
             HttpMessageNotReadableException.class})
     public ResponseEntity<Object> handleBadRequestException(Exception ex, WebRequest request) {

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/SerDesException.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/exceptions/SerDesException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.pscdataapi.exceptions;
+
+public class SerDesException extends RuntimeException {
+    public SerDesException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import org.assertj.core.api.Assertions;
@@ -40,6 +41,8 @@ class ChsKafkaApiServiceTest {
     private PrivateChangedResourcePost privateChangedResourcePost;
     @Mock
     private ApiResponse<Void> response;
+    @Mock
+    private ObjectMapper objectMapper;
     @InjectMocks
     private ChsKafkaApiService chsKafkaApiService;
     @Captor

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ResourceChangedApiServiceAspectFeatureFlagDisabledITest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ResourceChangedApiServiceAspectFeatureFlagDisabledITest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,8 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledITest {
     private ApiResponse<Void> response;
     @Mock
     private HttpClient httpClient;
+    @Mock
+    private ObjectMapper objectMapper;
 
     @MockBean
     private ChsKafkaApiService mapper;

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNot.not;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -18,10 +19,12 @@ class ApplicationConfigTest {
     void setUp() {
         applicationConfig = new ApplicationConfig();
     }
+
     @Test
     void mongoCustomConversions() {
-        assertThat(applicationConfig.mongoCustomConversions(), is(not(nullValue())));
-        assertThat(applicationConfig.mongoCustomConversions(), isA(MongoCustomConversions.class));
+        ObjectMapper objectMapper = new ObjectMapper();
+        assertThat(applicationConfig.mongoCustomConversions(objectMapper), is(not(nullValue())));
+        assertThat(applicationConfig.mongoCustomConversions(objectMapper), isA(MongoCustomConversions.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/config/ApplicationConfigTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNot.not;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -19,12 +18,10 @@ class ApplicationConfigTest {
     void setUp() {
         applicationConfig = new ApplicationConfig();
     }
-
     @Test
     void mongoCustomConversions() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        assertThat(applicationConfig.mongoCustomConversions(objectMapper), is(not(nullValue())));
-        assertThat(applicationConfig.mongoCustomConversions(objectMapper), isA(MongoCustomConversions.class));
+        assertThat(applicationConfig.mongoCustomConversions(), is(not(nullValue())));
+        assertThat(applicationConfig.mongoCustomConversions(), isA(MongoCustomConversions.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.api.psc.CorporateEntity;
 import uk.gov.companieshouse.api.psc.CorporateEntityBeneficialOwner;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
@@ -35,6 +34,7 @@ import uk.gov.companieshouse.api.psc.PscList;
 import uk.gov.companieshouse.api.psc.SuperSecure;
 import uk.gov.companieshouse.api.psc.SuperSecureBeneficialOwner;
 import uk.gov.companieshouse.pscdataapi.exceptions.ResourceNotFoundException;
+import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
 import uk.gov.companieshouse.pscdataapi.service.CompanyPscService;
 import uk.gov.companieshouse.pscdataapi.util.TestHelper;
@@ -170,7 +170,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getSuperSecurePsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID);
 
@@ -236,7 +236,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getSuperSecureBeneficialOwnerPsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID);
 
@@ -321,7 +321,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getCorporateEntityPsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID);
 
@@ -451,7 +451,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getIndividualPsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID, MOCK_REGISTER_VIEW_TRUE);
 
@@ -525,7 +525,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getIndividualBeneficialOwnerPsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID, MOCK_REGISTER_VIEW_FALSE);
 
@@ -588,7 +588,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getCorporateEntityBeneficialOwnerPsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID);
 
@@ -651,7 +651,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getLegalPersonPsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID);
 
@@ -713,7 +713,7 @@ class CompanyPscControllerTest {
                         .header("x-request-id", X_REQUEST_ID)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES)
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isServiceUnavailable());
 
         verify(companyPscService).getLegalPersonBeneficialOwnerPsc(MOCK_COMPANY_NUMBER, MOCK_NOTIFICATION_ID);
 


### PR DESCRIPTION
This PR fixes a bug where null fields were returned in the GET response body, and where null fields were being sent on the resource-changed message.

The fix was to add an Jackson object mapper bean to the application config which does not allow for null fields.

Tested locally.

[DSND-2801](https://companieshouse.atlassian.net/browse/DSND-2801)

[DSND-2801]: https://companieshouse.atlassian.net/browse/DSND-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ