### PR TITLE
Fix ECS routing priority so psc-statement-data-api routes are hit first

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -8,7 +8,7 @@ locals {
   eric_port                   = "10000"
   docker_repo                 = "psc-data-api"
   kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
-  lb_listener_rule_priority   = 84
+  lb_listener_rule_priority   = 88
   lb_listener_paths           = [
     "/psc-data-api/healthcheck", "/company/*/persons-with-significant-control*"
   ]


### PR DESCRIPTION
[DSND-2699](https://companieshouse.atlassian.net/browse/DSND-2699)

[DSND-2699]: https://companieshouse.atlassian.net/browse/DSND-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ