### PR TITLE
DSND-3027: Change processing order for upserts

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.mongodb.repository.Query;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
 
 public interface CompanyPscRepository extends MongoRepository<PscDocument, String> {
-    @Query("{'_id': ?0, 'delta_at':{$gte : \"?1\" }}")
+    @Query("{'_id': ?0, 'delta_at':{$gt : '?1' }}")
     List<PscDocument> findUpdatedPsc(String notificationId, String at);
 
     @Query("{'_id' : ?1, 'company_number' : ?0}")

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateDeSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/serialization/LocalDateDeSerializer.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -27,7 +27,7 @@ public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
             JsonNode jsonNode = jsonParser.readValueAsTree();
             JsonNode dateNode = jsonNode.get("$date");
 
-            /** If textValue() returns a value we received a string of
+            /* If textValue() returns a value we received a string of
              * format yyyy-MM-dd'T'HH:mm:ss'Z
              * and use dateTimeFormatter to return LocalDate.
              * 
@@ -38,7 +38,7 @@ public class LocalDateDeSerializer extends JsonDeserializer<LocalDate> {
             return dateNode.textValue() != null
                     ? LocalDate.parse(dateNode.textValue(), dateTimeFormatter)
                     : LocalDate.ofInstant(Instant.ofEpochMilli(dateNode.get("$numberLong")
-                    .asLong()), ZoneId.systemDefault());
+                            .asLong()), ZoneOffset.UTC);
         } catch (Exception exception) {
             LOGGER.error("Deserialization failed.", exception);
             throw new BadRequestException(exception.getMessage());

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -81,7 +81,6 @@ public class CompanyPscService {
      * @param contextId   Id used for chsKafkaCall.
      * @param requestBody Data to be saved.
      */
-    @Transactional
     public void insertPscRecord(String contextId, FullRecordCompanyPSCApi requestBody)
             throws ServiceUnavailableException, BadRequestException {
 

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
@@ -6,7 +6,6 @@ import java.io.InputStreamReader;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -65,8 +64,6 @@ public class TestHelper {
     public static final String PSC_STATEMENT_ID = "pscStatementId";
     public static final String X_REQUEST_ID = "654321";
     private static final LocalDate EXEMPTION_DATE = LocalDate.of(2022, 11, 3);
-
-    public TestHelper(){}
 
     public static FullRecordCompanyPSCApi buildFullRecordPsc(String kind) {
         return buildFullRecordPsc(kind, false, true);
@@ -501,13 +498,11 @@ public class TestHelper {
     static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
     public static OffsetDateTime createOffsetDateTime() {
         LocalDateTime localDate = LocalDateTime.parse("2023-01-02T13:04:05.678", formatter);
-        ZoneOffset offset = ZoneId.systemDefault().getRules().getOffset(localDate);
-        return OffsetDateTime.of(localDate, offset);
-    }
-    public static OffsetDateTime createLaterOffsetDateTime() {
-        LocalDateTime laterLocalDate = LocalDateTime.parse("2023-01-03T13:04:05.678", formatter);
-        ZoneOffset offset = ZoneId.systemDefault().getRules().getOffset(laterLocalDate);
-        return OffsetDateTime.of(laterLocalDate, offset);
+        return OffsetDateTime.of(localDate, ZoneOffset.UTC);
     }
 
+    public static OffsetDateTime createLaterOffsetDateTime() {
+        LocalDateTime laterLocalDate = LocalDateTime.parse("2023-01-03T13:04:05.678", formatter);
+        return OffsetDateTime.of(laterLocalDate, ZoneOffset.UTC);
+    }
 }


### PR DESCRIPTION
* Changed the `CompanyPscRepository.findUpdatedPsc()` method to return only newer documents
* Remove `@Transactional` from the `insertPscRecord()` method
* Added verification of the calls to `chsKafkaApiService`
* Changed the date parser to always use UTC

[DSND-3027](https://companieshouse.atlassian.net/browse/DSND-3027)

[DSND-3027]: https://companieshouse.atlassian.net/browse/DSND-3027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ