### PR TITLE
DSND-3213: Handle 404 from exemptions api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyExemptionsApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyExemptionsApiService.java
@@ -15,7 +15,6 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.pscdataapi.exceptions.BadGatewayException;
-import uk.gov.companieshouse.pscdataapi.exceptions.ResourceNotFoundException;
 import uk.gov.companieshouse.pscdataapi.logging.DataMapHolder;
 
 @Component
@@ -31,7 +30,7 @@ public class CompanyExemptionsApiService {
     }
 
     public Optional<CompanyExemptions> getCompanyExemptions(final String companyNumber) {
-        ApiResponse<CompanyExemptions> response;
+        ApiResponse<CompanyExemptions> response = null;
         try {
             response = exemptionsApiClientSupplier.get()
                     .privateDeltaResourceHandler()
@@ -39,12 +38,9 @@ public class CompanyExemptionsApiService {
                     .execute();
         } catch (ApiErrorResponseException ex) {
             final int statusCode = ex.getStatusCode();
-            LOGGER.info("Company Exemptions API call failed with status code [%s]".formatted(statusCode),
+            LOGGER.info("Company Exemptions API GET failed with status code [%s]".formatted(statusCode),
                     DataMapHolder.getLogMap());
-            if (statusCode == 404) {
-                throw new ResourceNotFoundException(HttpStatus.NOT_FOUND,
-                        "Company Exemptions API responded with 404 Not Found");
-            } else {
+            if (statusCode != 404) {
                 throw new BadGatewayException("Error calling Company Exemptions API endpoint", ex);
             }
         } catch (URIValidationException ex) {

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyExemptionsApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyExemptionsApiServiceTest.java
@@ -89,7 +89,7 @@ class CompanyExemptionsApiServiceTest {
     }
 
     @Test
-    void shouldThrowResourceNotFoundExceptionWhenApiRespondsWith404NotFound() throws Exception {
+    void shouldReturnEmptyOptionalWhenApiRespondsWith404NotFound() throws Exception {
         // given
         when(supplier.get()).thenReturn(client);
         when(client.privateDeltaResourceHandler()).thenReturn(privateDeltaResourceHandler);
@@ -98,11 +98,11 @@ class CompanyExemptionsApiServiceTest {
         when(privateCompanyExemptionsGetAll.execute()).thenThrow(buildApiErrorResponseException(404));
 
         // when
-        Executable executable = () -> service.getCompanyExemptions(COMPANY_NUMBER);
+        final Optional<CompanyExemptions> actual = service.getCompanyExemptions(COMPANY_NUMBER);
 
         // then
-        assertThrows(ResourceNotFoundException.class, executable);
         verify(privateDeltaResourceHandler).getCompanyExemptionsResource(URL);
+        assertEquals(Optional.empty(), actual);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* Behaviour has been changed to return an empty optional when exemptions GET returns 404. Rather than throw an exception. It's possible to have PSCs without exemptions.

[DSND-3213](https://companieshouse.atlassian.net/browse/DSND-3213)

[DSND-3213]: https://companieshouse.atlassian.net/browse/DSND-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ