### PR TITLE
Internal_id will be stored in the sensitive data block in the db

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscData.java
@@ -63,9 +63,6 @@ public class PscData {
     @JsonProperty("identification")
     private PscIdentification identification;
 
-    @JsonProperty("internal_id")
-    private Long internalId;
-
     public Address getPrincipalOfficeAddress() {
         return principalOfficeAddress;
     }
@@ -204,14 +201,6 @@ public class PscData {
         this.ceased = ceased;
     }
 
-    public Long getInternalId() {
-        return internalId;
-    }
-
-    public void setInternalId(final Long internalId) {
-        this.internalId = internalId;
-    }
-
     @Override
     public String toString() {
         return "PscData{"
@@ -253,8 +242,6 @@ public class PscData {
                 + links
                 + ", identification="
                 + identification
-                + ", internalId="
-                + internalId
                 + '}';
     }
 
@@ -283,8 +270,7 @@ public class PscData {
                 && Objects.equals(naturesOfControl, pscData.naturesOfControl)
                 && Objects.equals(nameElements, pscData.nameElements)
                 && Objects.equals(links, pscData.links)
-                && Objects.equals(identification, pscData.identification)
-                && Objects.equals(internalId, pscData.internalId);
+                && Objects.equals(identification, pscData.identification);
     }
 
     @Override
@@ -292,6 +278,6 @@ public class PscData {
         return Objects.hash(ceasedOn, etag, address, name, nationality, countryOfResidence,
                 kind, notifiedOn, description, serviceAddressIsSameAsRegisteredOfficeAddress,
                 isSanctioned, ceased, naturesOfControl,
-                nameElements, links, identification, internalId);
+                nameElements, links, identification);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscSensitiveData.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscSensitiveData.java
@@ -10,6 +10,8 @@ public class PscSensitiveData {
     private DateOfBirth dateOfBirth;
     @JsonProperty("residential_address_is_same_as_service_address")
     private Boolean residentialAddressIsSameAsServiceAddress;
+    @JsonProperty("internal_id")
+    private Long internalId;
 
     public Address getUsualResidentialAddress() {
         return usualResidentialAddress;
@@ -37,6 +39,14 @@ public class PscSensitiveData {
                 = residentialAddressIsSameAsServiceAddress;
     }
 
+    public Long getInternalId() {
+        return internalId;
+    }
+
+    public void setInternalId(final Long internalId) {
+        this.internalId = internalId;
+    }
+
     @Override
     public String toString() {
         return "PscSensitiveData{"
@@ -46,6 +56,8 @@ public class PscSensitiveData {
                 + dateOfBirth
                 + ", residentialAddressIsSameAsServiceAddress="
                 + residentialAddressIsSameAsServiceAddress
+                + ", internalId="
+                + internalId
                 + '}';
     }
 
@@ -61,12 +73,13 @@ public class PscSensitiveData {
         return Objects.equals(usualResidentialAddress, that.usualResidentialAddress)
                 && Objects.equals(dateOfBirth, that.dateOfBirth)
                 && Objects.equals(residentialAddressIsSameAsServiceAddress,
-                that.residentialAddressIsSameAsServiceAddress);
+                that.residentialAddressIsSameAsServiceAddress)
+                && Objects.equals(internalId, that.internalId);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(usualResidentialAddress, dateOfBirth,
-                residentialAddressIsSameAsServiceAddress);
+                residentialAddressIsSameAsServiceAddress, internalId);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
@@ -106,12 +106,12 @@ public class CompanyPscTransformer {
         individualFullRecord.setLinks(mapLinksToList(pscData.getLinks()));
         individualFullRecord.serviceAddress(mapFullRecordAddress(pscData.getAddress()));
         individualFullRecord.setEtag(pscData.getEtag());
-        individualFullRecord.setInternalId(pscData.getInternalId());
 
         final PscSensitiveData sensitivePscData = pscDocument.getSensitiveData();
         individualFullRecord.setResidentialAddressSameAsServiceAddress(sensitivePscData.getResidentialAddressIsSameAsServiceAddress());
         individualFullRecord.setDateOfBirth(mapDateOfBirth(sensitivePscData.getDateOfBirth(), true));
         individualFullRecord.setUsualResidentialAddress(mapFullRecordAddress(sensitivePscData.getUsualResidentialAddress()));
+        individualFullRecord.setInternalId(sensitivePscData.getInternalId());
 
         return individualFullRecord;
     }


### PR DESCRIPTION
Correction to #169 
The model and transformer needs to handle the internal_id being in the sensitive data block in the database.
No change to the structure of the Individual Full record returned by API though.

So:
![Screenshot 2025-02-11 at 2 24 03 pm](https://github.com/user-attachments/assets/5bc0c22f-b638-49ec-be02-73c8e674d231)

leads to:
![Screenshot 2025-02-11 at 2 24 54 pm](https://github.com/user-attachments/assets/8581a06f-081c-45b4-90b5-45ed98ee442e)

IDVA3-2688