### PR TITLE
Add null check for internal-id in psc-data when doing full_record call

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -212,9 +212,13 @@ public class CompanyPscService {
                 }
 
                 if (featureFlags.isIndividualPscFullRecordAddVerificationStateEnabled()) {
-                    oracleQueryApiService.getPscVerificationState(individualFullRecord.getInternalId())
-                            .map(verificationStateMapper::mapToVerificationState)
-                            .ifPresent(individualFullRecord::setVerificationState);
+                    if (individualFullRecord.getInternalId() != null) {
+                        oracleQueryApiService.getPscVerificationState(individualFullRecord.getInternalId())
+                                .map(verificationStateMapper::mapToVerificationState)
+                                .ifPresent(individualFullRecord::setVerificationState);
+                    } else {
+                        logger.error("Internal ID not found in PSC document.", DataMapHolder.getLogMap());
+                    }
                 }
                 return individualFullRecord;
 


### PR DESCRIPTION
- without this, the `/full_record` call will return 404 if there is no internal_id in the collection.   This then causes issues in the PSC Verification API when it attempts validation.
- with this null check, it will return a full_record, though without the `internal_id` or `verification_state`

Note - was the Feature Flag `FEATURE_FLAG_PSC_INDIVIDUAL_FULL_RECORD_ADD_VERIFICATION_STATE_180225` added with this situation in mind?  I think we still need it (?)