### PR TITLE
Fix unpredictable sorting in PSC list aggregation queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <java.version>21</java.version>
         <start-class>uk.gov.companieshouse.pscdataapi.PscDataApiApplication</start-class>
-        <spring-boot-dependencies.version>3.4.2</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.4.1</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.4.4</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.4.4</spring-boot-maven-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <structured-logging.version>3.0.20</structured-logging.version>
         <private-api-sdk-java.version>4.0.269</private-api-sdk-java.version>
         <api-sdk-java.version>6.0.36</api-sdk-java.version>
-        <api-security-java.version>2.0.5</api-security-java.version>
+        <api-security-java.version>2.0.8</api-security-java.version>
 
         <!-- tests -->
         <io-cucumber.version>7.20.1</io-cucumber.version>

--- a/src/itest/java/uk/gov/companieshouse/pscdataapi/CucumberFeaturesRunnerIT.java
+++ b/src/itest/java/uk/gov/companieshouse/pscdataapi/CucumberFeaturesRunnerIT.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.pscdataapi;
 
 import io.cucumber.spring.CucumberContextConfiguration;
+import org.junit.platform.suite.api.IncludeEngines;
 import org.junit.platform.suite.api.SelectClasspathResource;
 import org.junit.platform.suite.api.Suite;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +17,7 @@ import uk.gov.companieshouse.pscdataapi.service.CompanyExemptionsApiService;
 import uk.gov.companieshouse.pscdataapi.service.CompanyMetricsApiService;
 
 @Suite
+@IncludeEngines("cucumber")
 @SelectClasspathResource("features")
 @CucumberContextConfiguration
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/repository/CompanyPscRepository.java
@@ -20,7 +20,7 @@ public interface CompanyPscRepository extends MongoRepository<PscDocument, Strin
 
     @Aggregation(pipeline = {
             "{'$match': { 'company_number': ?0} } }",
-            "{'$sort': {'data.notified_on': -1, 'data.ceased_on': -1 } }",
+            "{'$sort': {'data.notified_on': -1, 'data.ceased_on': -1, 'created.at': 1 } }",
             "{'$skip': ?1}",
             "{'$limit': ?2}",
             })
@@ -30,7 +30,7 @@ public interface CompanyPscRepository extends MongoRepository<PscDocument, Strin
             "{'$match': { 'company_number' : ?0, "
                     + "$or:[ { '" + "data.ceased_on': { $gte : { \"$date\" : \"?2\" }} },"
                     + "{ 'data.ceased_on': {$exists: false }} ]} }",
-            "{'$sort': {'data.notified_on': -1, 'data.ceased_on': -1 } }",
+            "{'$sort': {'data.notified_on': -1, 'data.ceased_on': -1, 'created.at': 1 } }",
             "{'$skip': ?1}",
             "{'$limit': ?3}",
             })


### PR DESCRIPTION
Added sort criteria `created.at` timestamp as the most suitable fix. `_id` cannot be used as it's a hash-like alphanumeric string with no sequential ordering, .e.g. `"pnrzEhsZpr0qfaTE4Hgl_SR_SaU"`