### PR TITLE
Add missing sonar.jacoco.reports value for report paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <!--sonar configuration-->
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>
+        <sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
         <sonar.password></sonar.password>
@@ -278,17 +279,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>pre-unit-test</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Sets the path to the file which contains the execution model. -->
-                            <destFile>${sonar.jacoco.reports}/jacoco.exec</destFile>
-                            <propertyName>surefireArgLine</propertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>post-unit-test</id>
                         <phase>test</phase>
                         <goals>
@@ -307,7 +297,7 @@
                         </goals>
                         <configuration>
                             <!-- Sets the path to the file which contains the execution model. -->
-                            <destFile>${sonar.jacoco.reports}/jacoco-it.exec</destFile>
+                            <destFile>${project.basedir}/target/jacoco-it.exec</destFile>
                             <propertyName>failsafeArgLine</propertyName>
                         </configuration>
                     </execution>
@@ -318,7 +308,7 @@
                             <goal>report</goal>
                         </goals>
                         <configuration>
-                            <dataFile>${sonar.jacoco.reports}/jacoco-it.exec</dataFile>
+                            <dataFile>${project.basedir}/target/jacoco-it.exec</dataFile>
                             <outputDirectory>${sonar.jacoco.reports}/jacoco-it</outputDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
**Jira ticket**: ASM-275 - SonarQube - Test Coverage Report 0%

## Brief description of the change(s)
`$sonar.jacoco.reports` wasn't set, but was being referenced elsewhere

This is the reason we see this in the pipeline, and presumably why there is no coverage in SonarQube
<img width="1553" height="292" alt="Screenshot 2025-08-20 at 9 30 20 am" src="https://github.com/user-attachments/assets/6cdf7c8e-0c02-4d6c-a5d6-f87d2ebc83b8" />

## Working example
<img width="667" height="181" alt="Screenshot 2025-08-20 at 9 28 53 am" src="https://github.com/user-attachments/assets/805c116a-e72a-41d8-8cc5-37080a721f70" />
