### PR TITLE
Use  private IndividualFullRecord and delta data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <!-- Internal -->
         <structured-logging.version>3.0.40</structured-logging.version>
-        <private-api-sdk-java.version>4.0.353</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-sdk-java.version>6.4.4</api-sdk-java.version>
         <api-security-java.version>2.0.13</api-security-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscFullRecordGetController.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscFullRecordGetController.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
+import uk.gov.companieshouse.api.psc.IndividualFullRecord;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.pscdataapi.logging.DataMapHolder;
@@ -27,7 +27,7 @@ public class CompanyPscFullRecordGetController {
     }
 
     @GetMapping("/company/{company_number}/persons-with-significant-control/individual/{notification_id}/full_record")
-    public ResponseEntity<PscIndividualFullRecordApi> getIndividualFullRecordPscData(
+    public ResponseEntity<IndividualFullRecord> getIndividualFullRecordPscData(
             @PathVariable("company_number") final String companyNumber,
             @PathVariable("notification_id") final String notificationId,
             final HttpServletRequest request) {
@@ -36,7 +36,7 @@ public class CompanyPscFullRecordGetController {
                 .companyNumber(companyNumber)
                 .itemId(notificationId);
         LOGGER.info("Getting full PSC record", DataMapHolder.getLogMap());
-        final PscIndividualFullRecordApi individualFullRecord = pscService.getIndividualFullRecord(companyNumber,
+        final IndividualFullRecord individualFullRecord = pscService.getIndividualFullRecord(companyNumber,
                 notificationId);
 
         LOGGER.info("Successfully retrieved full PSC record", DataMapHolder.getLogMap());

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
@@ -7,7 +7,6 @@ import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.common.Date3Tuple;
 import uk.gov.companieshouse.api.model.psc.NameElementsApi;
-import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
 import uk.gov.companieshouse.api.model.psc.PscIndividualWithIdentityVerificationDetailsApi;
 import uk.gov.companieshouse.api.model.psc.PscLinks;
 import uk.gov.companieshouse.api.psc.*;
@@ -98,31 +97,47 @@ public class CompanyPscTransformer {
      * @param pscDocument PSC.
      * @return PSC mongo Document.
      */
-    public PscIndividualFullRecordApi transformPscDocToIndividualFullRecord(final PscDocument pscDocument) {
+    public IndividualFullRecord transformPscDocToIndividualFullRecord(final PscDocument pscDocument) {
         LOGGER.info("Attempting to transform pscDocument to Individual Full Record", DataMapHolder.getLogMap());
 
-        final PscIndividualFullRecordApi pscIndividualFullRecordApi = new PscIndividualFullRecordApi();
+        final IndividualFullRecord individualFullRecord = new IndividualFullRecord();
         final PscData pscData = pscDocument.getData();
-        pscIndividualFullRecordApi.setName(pscData.getName());
-        pscIndividualFullRecordApi.setNameElements(mapNameElementsApi(pscData.getNameElements()));
-        pscIndividualFullRecordApi.setCountryOfResidence(pscData.getCountryOfResidence());
-        pscIndividualFullRecordApi.setNotifiedOn(pscData.getNotifiedOn());
-        pscIndividualFullRecordApi.setCeasedOn(pscData.getCeasedOn());
-        pscIndividualFullRecordApi.setNaturesOfControl(pscData.getNaturesOfControl());
-        pscIndividualFullRecordApi.setNationality(pscData.getNationality());
-        pscIndividualFullRecordApi.setKind(PscIndividualFullRecordApi.KindEnum.INDIVIDUAL_PERSON_WITH_SIGNIFICANT_CONTROL);
-        pscIndividualFullRecordApi.setLinks(mapLinksToPscLinks(pscData.getLinks()));
-        pscIndividualFullRecordApi.serviceAddress(mapCommonAddress(pscData.getAddress()));
-        pscIndividualFullRecordApi.setEtag(pscData.getEtag());
+        individualFullRecord.setName(pscData.getName());
+        individualFullRecord.setNameElements(mapNameElementsApi(pscData.getNameElements()));
+        individualFullRecord.setCountryOfResidence(pscData.getCountryOfResidence());
+        individualFullRecord.setNotifiedOn(pscData.getNotifiedOn());
+        individualFullRecord.setCeasedOn(pscData.getCeasedOn());
+        individualFullRecord.setNaturesOfControl(pscData.getNaturesOfControl());
+        individualFullRecord.setNationality(pscData.getNationality());
+        individualFullRecord.setKind(IndividualFullRecord.KindEnum.INDIVIDUAL_PERSON_WITH_SIGNIFICANT_CONTROL);
+        individualFullRecord.setLinks(mapLinksToPscLinks(pscData.getLinks()));
+        individualFullRecord.serviceAddress(mapAddress(pscData.getAddress()));
+        individualFullRecord.setEtag(pscData.getEtag());
+        individualFullRecord.setIdentityVerificationDetails(getIdentityVerificationDetails(pscData));
 
         final PscSensitiveData sensitivePscData = pscDocument.getSensitiveData();
-        pscIndividualFullRecordApi.setResidentialAddressSameAsServiceAddress(
+        individualFullRecord.setResidentialAddressSameAsServiceAddress(
                 sensitivePscData.getResidentialAddressIsSameAsServiceAddress());
-        pscIndividualFullRecordApi.setDateOfBirth(mapDate3Tuple(sensitivePscData.getDateOfBirth(), true));
-        pscIndividualFullRecordApi.setUsualResidentialAddress(mapCommonAddress(sensitivePscData.getUsualResidentialAddress()));
-        pscIndividualFullRecordApi.setInternalId(sensitivePscData.getInternalId());
+        individualFullRecord.setDateOfBirth(mapDate3Tuple(sensitivePscData.getDateOfBirth(), true));
+        individualFullRecord.setUsualResidentialAddress(mapAddress(sensitivePscData.getUsualResidentialAddress()));
+        individualFullRecord.setInternalId(sensitivePscData.getInternalId());
 
-        return pscIndividualFullRecordApi;
+        return individualFullRecord;
+    }
+
+    /**
+     * Extracts identity verification details from the provided {@link PscData} object.
+     *
+     * @param pscData the PSC data containing identity verification details
+     * @return an {@link IdentityVerificationDetails} object populated with relevant fields.
+     */
+    private static IdentityVerificationDetails getIdentityVerificationDetails(final PscData pscData) {
+        final IdentityVerificationDetails identityVerificationDetails = new IdentityVerificationDetails();
+        identityVerificationDetails.setAppointmentVerificationStartOn(pscData.getIdentityVerificationDetails().getAppointmentVerificationStartOn());
+        identityVerificationDetails.setAppointmentVerificationEndOn(pscData.getIdentityVerificationDetails().getAppointmentVerificationEndOn());
+        identityVerificationDetails.setAppointmentVerificationStatementDate(pscData.getIdentityVerificationDetails().getAppointmentVerificationStatementDate());
+        identityVerificationDetails.setAppointmentVerificationStatementDueOn(pscData.getIdentityVerificationDetails().getAppointmentVerificationStatementDueOn());
+        return identityVerificationDetails;
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscFullRecordGetControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscFullRecordGetControllerTest.java
@@ -18,12 +18,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.companieshouse.api.model.common.Address;
 import uk.gov.companieshouse.api.model.common.Date3Tuple;
 import uk.gov.companieshouse.api.model.psc.NameElementsApi;
-import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
 import uk.gov.companieshouse.api.model.psc.PscLinks;
-import uk.gov.companieshouse.api.model.psc.IdentityVerificationDetails;
+import uk.gov.companieshouse.api.psc.Address;
+import uk.gov.companieshouse.api.psc.IdentityVerificationDetails;
+import uk.gov.companieshouse.api.psc.IndividualFullRecord;
 import uk.gov.companieshouse.pscdataapi.exceptions.InternalDataException;
 import uk.gov.companieshouse.pscdataapi.exceptions.NotFoundException;
 import uk.gov.companieshouse.pscdataapi.service.CompanyPscService;
@@ -150,7 +150,7 @@ class CompanyPscFullRecordGetControllerTest {
                 .andExpect(status().isInternalServerError());
     }
 
-    private static PscIndividualFullRecordApi createFullRecord() {
+    private static IndividualFullRecord createFullRecord() {
         final Address serviceAddress = new Address();
         serviceAddress.setAddressLine1("addressLine1");
         serviceAddress.setPostalCode("CF12 3AB");
@@ -169,8 +169,14 @@ class CompanyPscFullRecordGetControllerTest {
         final PscLinks pscLinks = new PscLinks();
         pscLinks.setSelf("/company/123/persons-with-significant-control/456");
 
-        return new PscIndividualFullRecordApi()
-                .kind(PscIndividualFullRecordApi.KindEnum.INDIVIDUAL_PERSON_WITH_SIGNIFICANT_CONTROL)
+        final IdentityVerificationDetails identityVerificationDetails = new IdentityVerificationDetails();
+        identityVerificationDetails.setAppointmentVerificationStartOn(START_ON);
+        identityVerificationDetails.setAppointmentVerificationEndOn(END_ON);
+        identityVerificationDetails.setAppointmentVerificationStatementDate(STATEMENT_DATE);
+        identityVerificationDetails.setAppointmentVerificationStatementDueOn(STATEMENT_DUE_DATE);
+
+        return new IndividualFullRecord()
+                .kind(IndividualFullRecord.KindEnum.INDIVIDUAL_PERSON_WITH_SIGNIFICANT_CONTROL)
                 .name("Andy Bob Smith")
                 .nameElements(nameElementsApi)
                 .serviceAddress(serviceAddress)
@@ -181,8 +187,7 @@ class CompanyPscFullRecordGetControllerTest {
                 .dateOfBirth(new Date3Tuple(1, 2, 2000))
                 .internalId(123456789L)
                 .links(pscLinks)
-                .identityVerificationDetails(
-                        new IdentityVerificationDetails(START_ON, END_ON, STATEMENT_DATE, STATEMENT_DUE_DATE));
+                .identityVerificationDetails(identityVerificationDetails);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,14 +46,13 @@ import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.PscApi;
 import uk.gov.companieshouse.api.metrics.RegisterApi;
 import uk.gov.companieshouse.api.metrics.RegistersApi;
-import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
-import uk.gov.companieshouse.api.model.psc.IdentityVerificationDetailsApi;
 import uk.gov.companieshouse.api.psc.CorporateEntity;
 import uk.gov.companieshouse.api.psc.CorporateEntityBeneficialOwner;
 import uk.gov.companieshouse.api.psc.FullRecordCompanyPSCApi;
 import uk.gov.companieshouse.api.psc.Identification;
 import uk.gov.companieshouse.api.psc.Individual;
 import uk.gov.companieshouse.api.psc.IndividualBeneficialOwner;
+import uk.gov.companieshouse.api.psc.IndividualFullRecord;
 import uk.gov.companieshouse.api.psc.LegalPerson;
 import uk.gov.companieshouse.api.psc.LegalPersonBeneficialOwner;
 import uk.gov.companieshouse.api.psc.ListSummary;
@@ -902,8 +900,7 @@ class CompanyPscServiceTest {
     void getIndividualFullRecordShouldReturnFullRecordWhenFound_FlagVerificationDetailsFalse() {
         when(repository.getPscByCompanyNumberAndId(COMPANY_NUMBER, NOTIFICATION_ID)).thenReturn(
                 Optional.of(pscDocument));
-        when(featureFlags.isIndividualPscFullRecordAddidentityVerificationDetailsEnabled()).thenReturn(false);
-        when(transformer.transformPscDocToIndividualFullRecord(pscDocument)).thenReturn(new PscIndividualFullRecordApi());
+        when(transformer.transformPscDocToIndividualFullRecord(pscDocument)).thenReturn(new IndividualFullRecord());
 
         service.getIndividualFullRecord(COMPANY_NUMBER, NOTIFICATION_ID);
 
@@ -915,11 +912,8 @@ class CompanyPscServiceTest {
     void getIndividualFullRecordShouldReturnFullRecordWhenFound_FlagVerificationDetailsTrue() {
         when(repository.getPscByCompanyNumberAndId(COMPANY_NUMBER, NOTIFICATION_ID)).thenReturn(
                 Optional.of(pscDocument));
-        when(featureFlags.isIndividualPscFullRecordAddidentityVerificationDetailsEnabled()).thenReturn(true);
-        when(oracleQueryApiService.getIdentityVerificationDetails(123L))
-                .thenReturn(Optional.of(new IdentityVerificationDetailsApi(START_ON, END_ON, STATEMENT_DATE, STATEMENT_DUE_DATE)));
         when(transformer.transformPscDocToIndividualFullRecord(pscDocument)).thenReturn(
-                new PscIndividualFullRecordApi().internalId(123L));
+                new IndividualFullRecord().internalId(123L));
 
         service.getIndividualFullRecord(COMPANY_NUMBER, NOTIFICATION_ID);
 


### PR DESCRIPTION
**Jira ticket**: IDVA3-3384

## Brief description of the change(s)
- switch from PscIndividualFullRecordApi in api-sdk to IndividualFullRecord in private-sdk
- this will have delta data from the PSC Data API db, and not call Oracle Query API
- transformer mapping updated for this

see also PR's
- https://github.com/companieshouse/private.api.ch.gov.uk-specifications/pull/523
- https://github.com/companieshouse/private-api-sdk-java/pull/994

## Working example
<img width="893" height="904" alt="Screenshot 2025-09-15 at 3 58 35 pm" src="https://github.com/user-attachments/assets/7cde8b00-1bdd-424b-8f69-b079f12640c2" />

## Test notes
To test this locally use the private sdk in https://github.com/companieshouse/private-api-sdk-java/pull/994

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
