### PR TITLE
Replace deprecated setUseTrailingSlashMatch()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,9 +270,6 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco-maven-plugin.version}</version>
         <configuration>
-<!--          <excludes>-->
-<!--            <exclude>**/models/*</exclude>-->
-<!--          </excludes>-->
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
         <version>${jacoco-maven-plugin.version}</version>
         <configuration>
           <excludes>
-            <exclude>**/models/*.class</exclude>
+            <exclude>**/models/*.java</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -270,9 +270,9 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco-maven-plugin.version}</version>
         <configuration>
-          <excludes>
-            <exclude>**/models/*.java</exclude>
-          </excludes>
+<!--          <excludes>-->
+<!--            <exclude>**/models/*</exclude>-->
+<!--          </excludes>-->
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/WebSecurityConfig.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.pscdataapi.config;
 
 import java.util.List;
-
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.filter.UrlHandlerFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.api.filter.CustomCorsFilter;
@@ -73,4 +75,24 @@ public class WebSecurityConfig implements WebMvcConfigurer {
     public List<String> externalMethods() {
         return List.of(HttpMethod.GET.name());
     }
+
+    /**
+     * Preserve original behaviour of Spring Boot 2 to allow a trailing slash on service endpoints. This is to avoid
+     * negatively impacting external API users who may rely on it.
+     *
+     * @return the filter registration bean for the URL handler filter
+     */
+    @Bean
+    public FilterRegistrationBean<OncePerRequestFilter> urlHandlerFilterRegistrationBean() {
+        final FilterRegistrationBean<OncePerRequestFilter> registrationBean = new FilterRegistrationBean<>();
+
+        UrlHandlerFilter urlHandlerFilter = UrlHandlerFilter
+                                                .trailingSlashHandler("/company/*/persons-with-significant-control/**")
+                                                .wrapRequest()
+                                                .build();
+        registrationBean.setFilter(urlHandlerFilter);
+
+         return registrationBean;
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.pscdataapi.config;
 
 import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -10,9 +11,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.util.pattern.PathPatternParser;
 import uk.gov.companieshouse.api.filter.CustomCorsFilter;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.UserAuthenticationInterceptor;
@@ -25,28 +24,14 @@ public class WebSecurityConfig implements WebMvcConfigurer {
 
     public static final String PATTERN_FULL_RECORD =
             "/company/{company_number}/persons-with-significant-control/individual/{notification_id}/full_record";
-    public static final String PATTERN_IDENTITY_VERIFICATION_DETAILS =
-            "/company/{company_number}/persons-with-significant-control/individual/{notification_id}/identity-verification-details";
 
     List<String> otherAllowedAuthMethods = List.of("oauth2");
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(userAuthenticationInterceptor());
-        registry.addInterceptor(internalUserInterceptor())
-                .addPathPatterns(PATTERN_IDENTITY_VERIFICATION_DETAILS);
         registry.addInterceptor(fullRecordAuthenticationInterceptor())
                 .addPathPatterns(PATTERN_FULL_RECORD);
-    }
-
-    @Bean
-    public PathPatternParser pathPatternParser() {
-        return new PathPatternParser();
-    }
-
-    @Override
-    public void configurePathMatch(final PathMatchConfigurer configurer) {
-        configurer.setPatternParser(pathPatternParser());
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/config/WebSecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.pattern.PathPatternParser;
 import uk.gov.companieshouse.api.filter.CustomCorsFilter;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.UserAuthenticationInterceptor;
@@ -38,9 +39,14 @@ public class WebSecurityConfig implements WebMvcConfigurer {
                 .addPathPatterns(PATTERN_FULL_RECORD);
     }
 
+    @Bean
+    public PathPatternParser pathPatternParser() {
+        return new PathPatternParser();
+    }
+
     @Override
     public void configurePathMatch(final PathMatchConfigurer configurer) {
-        configurer.setUseTrailingSlashMatch(true);
+        configurer.setPatternParser(pathPatternParser());
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
@@ -221,8 +221,7 @@ public class CompanyPscController {
         return new ResponseEntity<>(superSecureBeneficialOwner, HttpStatus.OK);
     }
 
-    @GetMapping({"/company/{company_number}/persons-with-significant-control",
-                 "/company/{company_number}/persons-with-significant-control/"})
+    @GetMapping({"/company/{company_number}/persons-with-significant-control"})
     public ResponseEntity<PscList> searchPscListSummary(
             @PathVariable("company_number") String companyNumber,
             @RequestParam(value = "items_per_page", required = false, defaultValue = "25") Integer itemsPerPage,

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
@@ -221,7 +221,8 @@ public class CompanyPscController {
         return new ResponseEntity<>(superSecureBeneficialOwner, HttpStatus.OK);
     }
 
-    @GetMapping("/company/{company_number}/persons-with-significant-control")
+    @GetMapping({"/company/{company_number}/persons-with-significant-control",
+                 "/company/{company_number}/persons-with-significant-control/"})
     public ResponseEntity<PscList> searchPscListSummary(
             @PathVariable("company_number") String companyNumber,
             @RequestParam(value = "items_per_page", required = false, defaultValue = "25") Integer itemsPerPage,

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscController.java
@@ -221,7 +221,7 @@ public class CompanyPscController {
         return new ResponseEntity<>(superSecureBeneficialOwner, HttpStatus.OK);
     }
 
-    @GetMapping({"/company/{company_number}/persons-with-significant-control"})
+    @GetMapping("/company/{company_number}/persons-with-significant-control")
     public ResponseEntity<PscList> searchPscListSummary(
             @PathVariable("company_number") String companyNumber,
             @RequestParam(value = "items_per_page", required = false, defaultValue = "25") Integer itemsPerPage,


### PR DESCRIPTION
**Jira ticket**: ASM-1538

## Brief description of the change(s)
- `PathMatchConfigurer.setUseTrailingSlashMatch()` is deprecated so replaced with `UrlHandlerFilter.wrapRequest()` - see https://www.baeldung.com/spring-boot-3-url-matching
- removed path pattern for `/identity-verification-details` - see #211
- removed models exclusion from coverage since there are some tests for this

## Working examples (repeated after switching to `UrlHandlerFilter`)
- similar with and without `/` also done for
  - `{{base_url}}/company/{{company_number}}/persons-with-significant-control/individual/{{chs_psc_id}}(/)`
  - `{{base_url}}/company/{{company_number}}/persons-with-significant-control/individual/{{chs_psc_id}}/full_record(/)`

Individual PSC details:

<img width="781" height="838" alt="Screenshot 2026-02-25 at 1 48 35 pm" src="https://github.com/user-attachments/assets/8439b777-ce30-4045-bb52-be0e25eeb61b" />


PSC's for a company with a trailing slash:

<img width="816" height="772" alt="Screenshot 2026-02-25 at 1 50 11 pm" src="https://github.com/user-attachments/assets/4d8abf15-91be-422c-b73d-f950ce31172e" />


## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
