### PR TITLE
BI-15067 - Always send links object in company psc stream message

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -12,6 +12,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
+
+import uk.gov.companieshouse.api.appointment.OfficerSummary;
 import uk.gov.companieshouse.api.exemptions.CompanyExemptions;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.PscApi;
@@ -37,6 +39,7 @@ import uk.gov.companieshouse.pscdataapi.exceptions.NotFoundException;
 import uk.gov.companieshouse.pscdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscdataapi.models.Created;
 import uk.gov.companieshouse.pscdataapi.models.Links;
+import uk.gov.companieshouse.pscdataapi.models.PersonsWithSignificantControl;
 import uk.gov.companieshouse.pscdataapi.models.PscData;
 import uk.gov.companieshouse.pscdataapi.models.PscDeleteRequest;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
@@ -100,9 +103,26 @@ public class CompanyPscService {
             repository.delete(document);
             chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(deleteRequest, document);
         } else {
-            final String msg = "PSC document not found during delete";
+            final String msg = "PSC document not found during delete - publishing event with links.persons-with-significant-control only";
             LOGGER.info(msg, DataMapHolder.getLogMap());
-            chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(deleteRequest, document);
+            // Construct a PscDocument with links.persons-with-significant-control object to publish
+            final String pscUri = "/company/%s/persons-with-significant-control/%s".formatted(deleteRequest.companyNumber(), deleteRequest.notificationId());
+
+            PersonsWithSignificantControl psc = new PersonsWithSignificantControl();
+            psc.setSelf(pscUri);
+
+            Links links = new Links();
+            links.setPersonsWithSignificantControl(psc);
+
+            PscDocument pscDoc = new PscDocument();
+            pscDoc.setId(deleteRequest.notificationId());
+            pscDoc.setCompanyNumber(deleteRequest.companyNumber());
+
+            PscData pscData = new PscData();
+            pscData.setLinks(links);
+            pscDoc.setData(pscData);
+     
+            chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(deleteRequest, pscDoc);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 
-import uk.gov.companieshouse.api.appointment.OfficerSummary;
 import uk.gov.companieshouse.api.exemptions.CompanyExemptions;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.PscApi;

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
@@ -261,6 +261,29 @@ class CompanyPscServiceTest {
     }
 
     @Test
+        @DisplayName("Kafka delete event contains correct links object when PSC record is already deleted")
+        void testDeleteEventContainsCorrectLinksWhenRecordDeleted() {
+        when(repository.getPscByCompanyNumberAndId(COMPANY_NUMBER, NOTIFICATION_ID)).thenReturn(Optional.empty());
+
+        ArgumentCaptor<PscDocument> pscDoc = ArgumentCaptor.forClass(PscDocument.class);
+
+        service.deletePsc(new PscDeleteRequest(COMPANY_NUMBER, NOTIFICATION_ID, "", INDIVIDUAL_KIND, DELTA_AT));
+
+        verify(repository).getPscByCompanyNumberAndId(COMPANY_NUMBER, NOTIFICATION_ID);
+        verify(chsKafkaApiService).invokeChsKafkaApiWithDeleteEvent(any(), pscDoc.capture());
+
+        PscDocument dataSent = pscDoc.getValue();
+        assertNotNull(dataSent);
+        assertEquals(NOTIFICATION_ID, dataSent.getId());
+        assertEquals(COMPANY_NUMBER, dataSent.getCompanyNumber());
+        assertNotNull(dataSent.getData());
+        assertNotNull(dataSent.getData().getLinks());
+        assertNotNull(dataSent.getData().getLinks().getPersonsWithSignificantControl());
+        String expectedUri = "/company/" + COMPANY_NUMBER + "/persons-with-significant-control/" + NOTIFICATION_ID;
+        assertEquals(expectedUri, dataSent.getData().getLinks().getPersonsWithSignificantControl().getSelf());
+        }
+
+    @Test
     void deleteIndividualFullRecordThrowsConflictWhenDeltaAtCheckFails() {
         PscDocument document = new PscDocument();
         document.setDeltaAt(DELTA_AT);


### PR DESCRIPTION
Resolves [BI-15067](https://companieshouse.atlassian.net/browse/BI-15067)

-  Extending deletePsc functionality - When a psc delete request is made, in the instance where the Mongo record is deleted but the event fails to be streamed - then a PscDocument is created with a links.persons-with-significant-control object, so that this is always published in the company psc stream event message
- Test to check that Kafka delete event contains correct links object when PSC record is already deleted



[BI-15067]: https://companieshouse.atlassian.net/browse/BI-15067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ