### PR TITLE
Add condition to exclude pscLinks object from superSecure kind

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
@@ -488,7 +488,7 @@ public class CompanyPscTransformer {
         pscData.setKind(data.getKind());
         pscData.setNotifiedOn(data.getNotifiedOn());
         Links links = PscTransformationHelper.createLinks(data, pscStatementId);
-        createPscLinksObject(links, pscId);
+        createPscLinksObject(links, pscId, data.getKind());
         pscData.setLinks(links);
         pscData.setName(data.getName());
         pscData.setNationality(data.getNationality());
@@ -698,10 +698,15 @@ public class CompanyPscTransformer {
         return ivd;
     }
 
-    private void createPscLinksObject(Links links, String pscId) {
+    private void createPscLinksObject(Links links, String pscId, String kind) {
         if ( links == null) {
             return;
         }
+
+        if (isSuperSecureKind(kind)) {
+        links.setPersonsWithSignificantControl(null);
+        return;
+    }
 
         if (isPscLinksEnabled) {
             links.setPersonsWithSignificantControl(null);
@@ -720,9 +725,18 @@ public class CompanyPscTransformer {
         if (links == null) {
             return null;
         }
-        createPscLinksObject(links, document.getPscId());
+        createPscLinksObject(links, document.getPscId(),  document.getData() != null ? document.getData().getKind() : null);
 
         return links;
+    }
+
+    private boolean isSuperSecureKind(String kind) {
+        if (kind == null) {
+            return false;
+        }
+
+        return kind.equals("super-secure-person-with-significant-control")
+                || kind.equals("super-secure-beneficial-owner");
     }
 
      private static PersonsWithSignificantControlLink mapPersonsWithSignificantControl(PersonsWithSignificantControl input) {

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/util/TestHelper.java
@@ -263,10 +263,11 @@ public class TestHelper {
             links.setStatement("linkStatements");
         }
 
-        PersonsWithSignificantControl pscLinks = new PersonsWithSignificantControl();
-
-        pscLinks.setNotifications("/persons-with-significant-control/" + PSC_ID + "/notifications");
-        links.setPersonsWithSignificantControl(pscLinks);
+        if (!kind.contains("secure")) {
+            PersonsWithSignificantControl pscLinks = new PersonsWithSignificantControl();
+            pscLinks.setNotifications("/persons-with-significant-control/" + PSC_ID + "/notifications");
+            links.setPersonsWithSignificantControl(pscLinks);
+        }
         pscData.setLinks(links);
         pscData.setServiceAddressIsSameAsRegisteredOfficeAddress(false);
 


### PR DESCRIPTION

Ensure links.psc.notifcations data item is not created in mongo db for x2 super secure PSC types