### PR TITLE
GCI-2656 - Fix field name to use underscores instead of hyphens

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/Links.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/Links.java
@@ -17,7 +17,7 @@ public class Links {
     @Field("exemptions")
     private String exemptions;
 
-    @JsonProperty("persons-with-significant-control")
+    @JsonProperty("persons_with_significant_control")
     private PersonsWithSignificantControl personsWithSignificantControl;
 
     public String getSelf() {

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -104,7 +104,7 @@ public class CompanyPscService {
         } else {
             final String msg = "PSC document not found during delete - publishing event with links.persons_with_significant_control only";
             LOGGER.info(msg, DataMapHolder.getLogMap());
-            // Construct a PscDocument with links.links.persons_with_significant_control object to publish
+            // Construct a PscDocument with links.persons_with_significant_control object to publish
             final String pscUri = "/company/%s/persons-with-significant-control/%s".formatted(deleteRequest.companyNumber(), deleteRequest.notificationId());
 
             PersonsWithSignificantControl psc = new PersonsWithSignificantControl();

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -102,9 +102,9 @@ public class CompanyPscService {
             repository.delete(document);
             chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(deleteRequest, document);
         } else {
-            final String msg = "PSC document not found during delete - publishing event with links.persons-with-significant-control only";
+            final String msg = "PSC document not found during delete - publishing event with links.persons_with_significant_control only";
             LOGGER.info(msg, DataMapHolder.getLogMap());
-            // Construct a PscDocument with links.persons-with-significant-control object to publish
+            // Construct a PscDocument with links.links.persons_with_significant_control object to publish
             final String pscUri = "/company/%s/persons-with-significant-control/%s".formatted(deleteRequest.companyNumber(), deleteRequest.notificationId());
 
             PersonsWithSignificantControl psc = new PersonsWithSignificantControl();

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/controller/CompanyPscControllerTest.java
@@ -1118,7 +1118,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1134,7 +1134,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 
     // GET Individual Beneficial Owner
@@ -1148,7 +1148,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1161,7 +1161,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 
     // GET Corporate Entity
@@ -1175,7 +1175,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1188,7 +1188,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 
     // GET Corporate Entity Beneficial Owner
@@ -1202,7 +1202,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1215,7 +1215,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 
     // GET Legal Person
@@ -1229,7 +1229,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1242,7 +1242,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 
     // GET Legal Person Beneficial Owner
@@ -1256,7 +1256,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1269,7 +1269,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 
     // GET Super Secure
@@ -1283,7 +1283,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1296,7 +1296,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 
     // GET Super Secure Beneficial Owner
@@ -1310,7 +1310,7 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").exists());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").exists());
     }
 
     @Test
@@ -1323,6 +1323,6 @@ class CompanyPscControllerTest {
                 .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.links.persons-with-significant-control").doesNotExist());
+                .andExpect(jsonPath("$.links.persons_with_significant_control").doesNotExist());
     }
 }


### PR DESCRIPTION
The field `persons-with-significant-control` is using hyphens instead of underscores to store in mongo and is returned as a response in the API which is incorrect. This change fixes the data issue to use underscores `persons_with_significant_control`