### PR TITLE
ensure PSC delete events are published when Mongo record already deleted

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -96,7 +96,7 @@ public class ChsKafkaApiService {
             if (pscDocument != null) {
                 // This write-value/read-value is necessary to remove null fields during the jackson conversion
                 try {
-                    Object pscObject = switch (pscDocument.getData().getKind()) {
+                    Object pscObject = switch (kind) {
                         case "individual-person-with-significant-control" ->
                                 companyPscTransformer.transformPscDocToIndividual(pscDocument, false);
                         case INDIVIDUAL_BENEFICIAL_OWNER ->

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscService.java
@@ -104,8 +104,9 @@ public class CompanyPscService {
         } else {
             final String msg = "PSC document not found during delete - publishing event with links.persons_with_significant_control only";
             LOGGER.info(msg, DataMapHolder.getLogMap());
-            // Construct a PscDocument with links.persons_with_significant_control object to publish
-            final String pscUri = "/company/%s/persons-with-significant-control/%s".formatted(deleteRequest.companyNumber(), deleteRequest.notificationId());
+            // Construct a PscDocument with a notifications link for the delete event
+            final String pscUri = "/persons-with-significant-control/%s/notifications".formatted(
+                    deleteRequest.notificationId());
 
             PersonsWithSignificantControl psc = new PersonsWithSignificantControl();
             psc.setNotifications(pscUri);
@@ -115,9 +116,11 @@ public class CompanyPscService {
 
             PscDocument pscDoc = new PscDocument();
             pscDoc.setId(deleteRequest.notificationId());
+            pscDoc.setPscId(deleteRequest.notificationId());
             pscDoc.setCompanyNumber(deleteRequest.companyNumber());
 
             PscData pscData = new PscData();
+            pscData.setKind(deleteRequest.kind());
             pscData.setLinks(links);
             pscDoc.setData(pscData);
      

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.pscdataapi.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -43,7 +44,6 @@ import uk.gov.companieshouse.api.psc.LegalPersonBeneficialOwner;
 import uk.gov.companieshouse.api.psc.SuperSecure;
 import uk.gov.companieshouse.api.psc.SuperSecureBeneficialOwner;
 import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
-import uk.gov.companieshouse.pscdataapi.models.PscData;
 import uk.gov.companieshouse.pscdataapi.models.PscDeleteRequest;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
 import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
@@ -58,7 +58,6 @@ class ChsKafkaApiServiceTest {
     private static final String PSC_URI = "/company/%s/persons-with-significant-control/%s/%s";
     private static final DateTimeFormatter ROUNDED_TO_SECONDS_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-    private static final String KIND = "individual-person-with-significant-control";
 
     @InjectMocks
     private ChsKafkaApiService chsKafkaApiService;
@@ -80,8 +79,6 @@ class ChsKafkaApiServiceTest {
     private ApiResponse<Void> response;
     @Mock
     private PscDocument pscDocument;
-    @Mock
-    private PscData pscData;
 
     @Captor
     ArgumentCaptor<ChangedResource> changedResourceCaptor;
@@ -161,7 +158,7 @@ class ChsKafkaApiServiceTest {
         // when
         ApiResponse<?> apiResponse = chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(
                 new PscDeleteRequest(TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID,
-                        TestHelper.INDIVIDUAL_KIND, DELTA_AT),
+                        TestHelper.INDIVIDUAL_BO_KIND, DELTA_AT),
                 document);
         assertThat(apiResponse).isNotNull();
 
@@ -373,6 +370,36 @@ class ChsKafkaApiServiceTest {
                 CorporateEntityBeneficialOwner.class);
     }
 
+        @Test
+        void invokeChsKafkaEndpointWithDeleteUsesDeleteRequestKindWhenDocumentKindMissing()
+                        throws ApiErrorResponseException, JsonProcessingException {
+                // given
+                when(kafkaApiClientSupplier.get()).thenReturn(client);
+                when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+                when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
+                when(privateChangedResourcePost.execute()).thenReturn(response);
+
+                PscDocument document = TestHelper.buildPscDocument(TestHelper.INDIVIDUAL_KIND);
+                assertNotNull(document.getData());
+                document.getData().setKind(null);
+
+                Individual individual = new Individual();
+                individual.setKind(Individual.KindEnum.INDIVIDUAL_PERSON_WITH_SIGNIFICANT_CONTROL);
+                when(companyPscTransformer.transformPscDocToIndividual(document, false)).thenReturn(individual);
+                when(objectMapper.writeValueAsString(individual)).thenReturn(individual.toString());
+                when(objectMapper.readValue(individual.toString(), Object.class)).thenReturn(individual);
+
+                // when
+                ApiResponse<?> apiResponse = chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(
+                                new PscDeleteRequest(COMPANY_NUMBER, NOTIFICATION_ID, X_REQUEST_ID, TestHelper.INDIVIDUAL_KIND, DELTA_AT),
+                                document);
+                assertThat(apiResponse).isNotNull();
+
+                // then
+                verify(privateChangedResourceHandler, times(1)).postChangedResource(any(), changedResourceCaptor.capture());
+                assertThat(changedResourceCaptor.getValue().getDeletedData()).isInstanceOf(Individual.class);
+        }
+
     @Test
     void invokeChsKafkaEndpointThrowsApiErrorException() throws ApiErrorResponseException {
         ApiErrorResponseException exception = new ApiErrorResponseException(
@@ -400,8 +427,6 @@ class ChsKafkaApiServiceTest {
         when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenThrow(exception);
-        when(pscDocument.getData()).thenReturn(pscData);
-        when(pscData.getKind()).thenReturn(KIND);
 
         Executable executable = () -> chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(
                 new PscDeleteRequest(TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID,
@@ -439,8 +464,6 @@ class ChsKafkaApiServiceTest {
         when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenThrow(exception);
-        when(pscDocument.getData()).thenReturn(pscData);
-        when(pscData.getKind()).thenReturn(KIND);
 
         Executable executable = () -> chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(
                 new PscDeleteRequest(TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID,

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ResourceChangedApiServiceAspectFeatureFlagDisabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ResourceChangedApiServiceAspectFeatureFlagDisabledIT.java
@@ -1,12 +1,15 @@
 package uk.gov.companieshouse.pscdataapi.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.function.Supplier;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -20,10 +23,11 @@ import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
-import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.psc.Individual;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.pscdataapi.models.PscDeleteRequest;
+import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
 import uk.gov.companieshouse.pscdataapi.util.TestHelper;
 
 @SpringBootTest
@@ -37,15 +41,11 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
 
     @MockitoBean
     private ApiClientService apiClientService;
-    @MockitoBean
-    private ChsKafkaApiService mapper;
 
     @Mock
     private Supplier<InternalApiClient> kafkaApiClientSupplier;
     @Mock
     private InternalApiClient client;
-    @Mock
-    private ChangedResource changedResource;
     @Mock
     private PrivateChangedResourceHandler privateChangedResourceHandler;
     @Mock
@@ -53,9 +53,9 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
     @Mock
     private ApiResponse<Void> response;
     @Mock
-    private HttpClient httpClient;
-    @Mock
     private ObjectMapper objectMapper;
+    @Mock
+    private CompanyPscTransformer companyPscTransformer;
 
     @Test
     void testThatKafkaApiShouldBeCalledWhenFeatureFlagDisabled() throws ApiErrorResponseException {
@@ -69,7 +69,7 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
         ApiResponse<?> apiResponse = chsKafkaApiService.invokeChsKafkaApi(TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID,
                 "individual-person-with-significant-control");
 
-        Assertions.assertThat(apiResponse).isNotNull();
+        assertThat(apiResponse).isNotNull();
 
         verify(client).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
@@ -77,7 +77,7 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
     }
 
     @Test
-    void testThatKafkaApiShouldBeCalledOnDeleteWhenFeatureFlagDisabled() throws ApiErrorResponseException {
+    void testThatKafkaApiShouldBeCalledOnDeleteWhenFeatureFlagDisabled() throws ApiErrorResponseException, JsonProcessingException {
         when(kafkaApiClientSupplier.get()).thenReturn(client);
         when(client.privateChangedResourceHandler()).thenReturn(
                 privateChangedResourceHandler);
@@ -85,15 +85,27 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
                 changedResourcePost);
         when(changedResourcePost.execute()).thenReturn(response);
 
+        Individual individual = new Individual();
+        individual.setKind(Individual.KindEnum.INDIVIDUAL_PERSON_WITH_SIGNIFICANT_CONTROL);
+        when(companyPscTransformer.transformPscDocToIndividual(any(), eq(false))).thenReturn(individual);
+        when(objectMapper.writeValueAsString(individual)).thenReturn(individual.toString());
+        when(objectMapper.readValue(individual.toString(), Object.class)).thenReturn(individual);
+
         ApiResponse<?> apiResponse = chsKafkaApiService.invokeChsKafkaApiWithDeleteEvent(
                 new PscDeleteRequest(TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.NOTIFICATION_ID,
                         "individual-person-with-significant-control", "deltaAt"),
-                TestHelper.buildPscDocument("individual-persons-with-significant-control"));
+                TestHelper.buildPscDocument("individual-person-with-significant-control"));
 
-        Assertions.assertThat(apiResponse).isNotNull();
+        assertThat(apiResponse).isNotNull();
 
         verify(client).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(changedResourcePost, times(1)).execute();
+        verify(companyPscTransformer, times(2)).transformPscDocToIndividual(any(), eq(false));
+
+        ChangedResource captured = changedResourceCaptor.getValue();
+        assertThat(captured.getEvent().getType()).isEqualTo("deleted");
+        assertThat(captured.getDeletedData()).isInstanceOf(Individual.class);
+        assertThat(captured.getResourceKind()).isEqualTo("company-psc-individual");
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/service/CompanyPscServiceTest.java
@@ -276,11 +276,13 @@ class CompanyPscServiceTest {
         PscDocument dataSent = pscDoc.getValue();
         assertNotNull(dataSent);
         assertEquals(NOTIFICATION_ID, dataSent.getId());
+        assertEquals(NOTIFICATION_ID, dataSent.getPscId());
         assertEquals(COMPANY_NUMBER, dataSent.getCompanyNumber());
         assertNotNull(dataSent.getData());
+        assertEquals(INDIVIDUAL_KIND, dataSent.getData().getKind());
         assertNotNull(dataSent.getData().getLinks());
         assertNotNull(dataSent.getData().getLinks().getPersonsWithSignificantControl());
-        String expectedUri = "/company/" + COMPANY_NUMBER + "/persons-with-significant-control/" + NOTIFICATION_ID;
+        String expectedUri = "/persons-with-significant-control/" + NOTIFICATION_ID + "/notifications";
         assertEquals(expectedUri, dataSent.getData().getLinks().getPersonsWithSignificantControl().getNotifications());
         }
 


### PR DESCRIPTION
ChsKafkaApiService 
- ‘kind’ in the delete request is always populated, whereas `pscDocument.getData().getKind()` is null in the resilience scenario which caused the switch to fall through to default and produce an empty deletedData object

CompanyPscService 
- uri updated as old path was not the correct PSC notifications link format
- added setPscId as required to rebuild the notifications link during transformation
- added setKind so the switch case in ChsKafkaApiService always has a non-null value to match on

ChsKafkaApiServiceTest 
- removed stale stubs, fixed a test passing wrong kind INDIVIDUAL_KIND instead of INDIVIDUAL_BO_KIND) and added regression test for bug fix

CompanyPscServiceTest
- Added assertions for kind and pscId, as well as notifications URI to verify fallback works

ResourceChangedApiServiceAspectFeatureFlagDisabledIT 
- fixed a pre-existing NullPointerException in the delete test by mocking the transformer and Jackson serialisation and added assertions to verify the kafka event is constructed with the correct type, deleted data, and resource kind