### PR TITLE
Add durable stream outbox and scheduled replay for chs-kafka-api outages

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/PscDataApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/PscDataApiApplication.java
@@ -2,8 +2,10 @@ package uk.gov.companieshouse.pscdataapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PscDataApiApplication {
 
     public static final String APPLICATION_NAME_SPACE = "psc-data-api";

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -2,11 +2,16 @@ package uk.gov.companieshouse.pscdataapi.api;
 
 import java.time.Instant;
 import static java.time.ZoneOffset.UTC;
+import java.time.temporal.ChronoUnit;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.HashMap;
 import java.util.function.Supplier;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,6 +31,8 @@ import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.pscdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscdataapi.models.PscDeleteRequest;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.StreamEventOutboxDocument;
+import uk.gov.companieshouse.pscdataapi.repository.StreamEventOutboxRepository;
 import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
 import uk.gov.companieshouse.pscdataapi.util.PscTransformationHelper;
 
@@ -44,32 +51,39 @@ public class ChsKafkaApiService {
     public static final String CORPORATE_ENTITY_BENEFICIAL_OWNER = "corporate-entity-beneficial-owner";
     public static final String LEGAL_PERSON_BENEFICIAL_OWNER = "legal-person-beneficial-owner";
     public static final String SUPER_SECURE_BENEFICIAL_OWNER = "super-secure-beneficial-owner";
+    private static final int MAX_BACKOFF_SECONDS = 300;
 
     private final CompanyPscTransformer companyPscTransformer;
     private final Supplier<InternalApiClient> kafkaApiClientSupplier;
     private final ObjectMapper objectMapper;
+    private final StreamEventOutboxRepository streamEventOutboxRepository;
+    private final int outboxBatchSize;
 
     public ChsKafkaApiService(CompanyPscTransformer companyPscTransformer,
-            @Qualifier("kafkaApiClientSupplier") Supplier<InternalApiClient> kafkaApiClientSupplier, ObjectMapper objectMapper) {
+            @Qualifier("kafkaApiClientSupplier") Supplier<InternalApiClient> kafkaApiClientSupplier,
+            ObjectMapper objectMapper,
+            StreamEventOutboxRepository streamEventOutboxRepository,
+            @Value("${stream.outbox.batch_size:50}") int outboxBatchSize) {
         this.companyPscTransformer = companyPscTransformer;
         this.kafkaApiClientSupplier = kafkaApiClientSupplier;
         this.objectMapper = objectMapper;
+        this.streamEventOutboxRepository = streamEventOutboxRepository;
+        this.outboxBatchSize = outboxBatchSize > 0 ? outboxBatchSize : 50;
     }
 
     @StreamEvents
     public ApiResponse<Void> invokeChsKafkaApi(String companyNumber, String notificationId, String kind) {
+        ChangedResource changedResource = mapChangedResource(companyNumber, notificationId, kind, false, null);
         PrivateChangedResourcePost changedResourcePost =
                 kafkaApiClientSupplier.get()
                         .privateChangedResourceHandler()
-                        .postChangedResource(RESOURCE_CHANGED_URI,
-                                mapChangedResource(companyNumber, notificationId, kind,
-                                        false, null));
-        return handleApiCall(changedResourcePost);
+                .postChangedResource(RESOURCE_CHANGED_URI, changedResource);
+        return handleApiCall(changedResourcePost, changedResource);
     }
 
     @StreamEvents
     public ApiResponse<Void> invokeChsKafkaApiWithDeleteEvent(PscDeleteRequest deleteRequest, PscDocument pscDocument) {
-        Object changedResource = mapChangedResource(
+        ChangedResource changedResource = mapChangedResource(
                 deleteRequest.companyNumber(),
                 deleteRequest.notificationId(),
                 deleteRequest.kind(),
@@ -80,10 +94,33 @@ public class ChsKafkaApiService {
         PrivateChangedResourcePost changedResourcePost =
             kafkaApiClientSupplier.get()
                     .privateChangedResourceHandler()
-                    .postChangedResource(RESOURCE_CHANGED_URI,
-                            mapChangedResource(deleteRequest.companyNumber(),
-                                deleteRequest.notificationId(), deleteRequest.kind(), true, pscDocument));
-        return handleApiCall(changedResourcePost);
+                    .postChangedResource(RESOURCE_CHANGED_URI, changedResource);
+        return handleApiCall(changedResourcePost, changedResource);
+    }
+
+    @Scheduled(fixedDelayString = "${stream.outbox.retry_interval_ms:30000}")
+    public void replayOutboxEvents() {
+        List<StreamEventOutboxDocument> pendingEvents = streamEventOutboxRepository
+                .findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(
+                        Instant.now(),
+                        PageRequest.of(0, outboxBatchSize)
+                );
+
+        for (StreamEventOutboxDocument event : pendingEvents) {
+            try {
+                ChangedResource changedResource = objectMapper.readValue(event.getPayload(), ChangedResource.class);
+                PrivateChangedResourcePost changedResourcePost = kafkaApiClientSupplier.get()
+                        .privateChangedResourceHandler()
+                        .postChangedResource(RESOURCE_CHANGED_URI, changedResource);
+                changedResourcePost.execute();
+                streamEventOutboxRepository.delete(event);
+                LOGGER.info("Successfully replayed outbox stream event", DataMapHolder.getLogMap());
+            } catch (ApiErrorResponseException | RuntimeException ex) {
+                recordReplayFailure(event, ex);
+            } catch (JsonProcessingException ex) {
+                recordReplayFailure(event, ex);
+            }
+        }
     }
 
     private ChangedResource mapChangedResource(String companyNumber, String notificationId,
@@ -145,17 +182,51 @@ public class ChsKafkaApiService {
         return kindMap.get(kind);
     }
 
-    private ApiResponse<Void> handleApiCall(PrivateChangedResourcePost changedResourcePost) {
+    private ApiResponse<Void> handleApiCall(PrivateChangedResourcePost changedResourcePost, ChangedResource changedResource) {
         try {
             return changedResourcePost.execute();
         } catch (ApiErrorResponseException ex) {
             final String msg = "Unsuccessful call to resource-changed endpoint";
             LOGGER.error(msg, ex);
+            saveToOutbox(changedResource, ex);
             throw new ServiceUnavailableException(msg);
         } catch (RuntimeException ex) {
             LOGGER.error("Error occurred while calling resource-changed endpoint", ex);
+            saveToOutbox(changedResource, ex);
             throw ex;
         }
+    }
+
+    private void saveToOutbox(ChangedResource changedResource, Exception ex) {
+        try {
+            StreamEventOutboxDocument outboxDocument = new StreamEventOutboxDocument();
+            outboxDocument.setPayload(objectMapper.writeValueAsString(changedResource));
+            outboxDocument.setResourceUri(changedResource.getResourceUri());
+            outboxDocument.setResourceKind(changedResource.getResourceKind());
+            outboxDocument.setEventType(changedResource.getEvent() != null ? changedResource.getEvent().getType() : null);
+            outboxDocument.setAttempts(0);
+            outboxDocument.setCreatedAt(Instant.now());
+            outboxDocument.setNextAttemptAt(Instant.now());
+            outboxDocument.setLastError(ex.getMessage());
+            streamEventOutboxRepository.save(outboxDocument);
+        } catch (JsonProcessingException jsonEx) {
+            LOGGER.error("Failed to serialise changed resource for outbox persistence", jsonEx);
+        } catch (RuntimeException runtimeEx) {
+            LOGGER.error("Failed to persist outbox stream event", runtimeEx);
+        }
+    }
+
+    private void recordReplayFailure(StreamEventOutboxDocument event, Exception ex) {
+        int attempts = event.getAttempts() + 1;
+        event.setAttempts(attempts);
+        event.setLastError(ex.getMessage());
+        event.setNextAttemptAt(Instant.now().plus(calculateBackoffSeconds(attempts), ChronoUnit.SECONDS));
+        streamEventOutboxRepository.save(event);
+        LOGGER.error("Failed replaying outbox stream event", ex);
+    }
+
+    private long calculateBackoffSeconds(int attempts) {
+        return Math.min(MAX_BACKOFF_SECONDS, 1L << Math.min(attempts, 20));
     }
 
     private Object deserializedData(Object pscDocument) throws JsonProcessingException {

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiService.java
@@ -115,11 +115,9 @@ public class ChsKafkaApiService {
                 changedResourcePost.execute();
                 streamEventOutboxRepository.delete(event);
                 LOGGER.info("Successfully replayed outbox stream event", DataMapHolder.getLogMap());
-            } catch (ApiErrorResponseException | RuntimeException ex) {
-                recordReplayFailure(event, ex);
-            } catch (JsonProcessingException ex) {
-                recordReplayFailure(event, ex);
-            }
+                } catch (ApiErrorResponseException | JsonProcessingException | RuntimeException ex) {
+                    recordReplayFailure(event, ex);
+                }
         }
     }
 
@@ -203,7 +201,7 @@ public class ChsKafkaApiService {
             outboxDocument.setPayload(objectMapper.writeValueAsString(changedResource));
             outboxDocument.setResourceUri(changedResource.getResourceUri());
             outboxDocument.setResourceKind(changedResource.getResourceKind());
-            outboxDocument.setEventType(changedResource.getEvent() != null ? changedResource.getEvent().getType() : null);
+            outboxDocument.setEventType(changedResource.getEvent().getType());
             outboxDocument.setAttempts(0);
             outboxDocument.setCreatedAt(Instant.now());
             outboxDocument.setNextAttemptAt(Instant.now());

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/StreamEventOutboxDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/StreamEventOutboxDocument.java
@@ -1,0 +1,109 @@
+package uk.gov.companieshouse.pscdataapi.models;
+
+import java.time.Instant;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "stream_event_outbox")
+public class StreamEventOutboxDocument {
+
+    @Id
+    private String id;
+
+    @Field("payload")
+    private String payload;
+
+    @Field("resource_uri")
+    private String resourceUri;
+
+    @Field("resource_kind")
+    private String resourceKind;
+
+    @Field("event_type")
+    private String eventType;
+
+    @Field("attempts")
+    private int attempts;
+
+    @Field("created_at")
+    private Instant createdAt;
+
+    @Field("next_attempt_at")
+    private Instant nextAttemptAt;
+
+    @Field("last_error")
+    private String lastError;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public String getResourceUri() {
+        return resourceUri;
+    }
+
+    public void setResourceUri(String resourceUri) {
+        this.resourceUri = resourceUri;
+    }
+
+    public String getResourceKind() {
+        return resourceKind;
+    }
+
+    public void setResourceKind(String resourceKind) {
+        this.resourceKind = resourceKind;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public int getAttempts() {
+        return attempts;
+    }
+
+    public void setAttempts(int attempts) {
+        this.attempts = attempts;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getNextAttemptAt() {
+        return nextAttemptAt;
+    }
+
+    public void setNextAttemptAt(Instant nextAttemptAt) {
+        this.nextAttemptAt = nextAttemptAt;
+    }
+
+    public String getLastError() {
+        return lastError;
+    }
+
+    public void setLastError(String lastError) {
+        this.lastError = lastError;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/repository/StreamEventOutboxRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/repository/StreamEventOutboxRepository.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.pscdataapi.repository;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import uk.gov.companieshouse.pscdataapi.models.StreamEventOutboxDocument;
+
+public interface StreamEventOutboxRepository extends MongoRepository<StreamEventOutboxDocument, String> {
+
+    List<StreamEventOutboxDocument> findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(Instant now, Pageable pageable);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,4 +17,6 @@ spring.mvc.throw-exception-if-no-handler-found=false
 spring.data.jackson.default-property-inclusion=NON_NULL
 feature.seeding_collection_enabled=${SEEDING_COLLECTION_ENABLED:false}
 psc.links.enabled=${FEATURE_FLAG_PSC_LINKS_ENABLED:true}
+stream.outbox.retry_interval_ms=${STREAM_OUTBOX_RETRY_INTERVAL_MS:30000}
+stream.outbox.batch_size=${STREAM_OUTBOX_BATCH_SIZE:50}
 server.port=${PORT:8081}

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -72,9 +72,8 @@ class ChsKafkaApiServiceTest {
     private ObjectMapper objectMapper;
     @Mock
     private CompanyPscTransformer companyPscTransformer;
-        @Mock
-        private StreamEventOutboxRepository streamEventOutboxRepository;
-
+    @Mock
+    private StreamEventOutboxRepository streamEventOutboxRepository;
     @Mock
     private InternalApiClient client;
     @Mock

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -88,16 +88,16 @@ class ChsKafkaApiServiceTest {
     @Captor
     ArgumentCaptor<ChangedResource> changedResourceCaptor;
 
-        @BeforeEach
-        void setUp() {
-                chsKafkaApiService = new ChsKafkaApiService(
-                                companyPscTransformer,
-                                kafkaApiClientSupplier,
-                                objectMapper,
-                                streamEventOutboxRepository,
-                                outboxBatchSize
-                );
-        }
+    @BeforeEach
+    void setUp() {
+        chsKafkaApiService = new ChsKafkaApiService(
+                        companyPscTransformer,
+                        kafkaApiClientSupplier,
+                        objectMapper,
+                        streamEventOutboxRepository,
+                        outboxBatchSize
+        );
+    }
 
     @Test
     void invokeChsKafkaEndpoint() throws ApiErrorResponseException {
@@ -432,7 +432,7 @@ class ChsKafkaApiServiceTest {
         verify(client, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
-                verify(streamEventOutboxRepository, times(1)).save(any(StreamEventOutboxDocument.class));
+        verify(streamEventOutboxRepository, times(1)).save(any(StreamEventOutboxDocument.class));
         assertThat(changedResourceCaptor.getValue().getEvent().getType()).isEqualTo(EVENT_TYPE_CHANGED);
     }
 
@@ -453,56 +453,54 @@ class ChsKafkaApiServiceTest {
         verify(client, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
-                verify(streamEventOutboxRepository, times(1)).save(any(StreamEventOutboxDocument.class));
+        verify(streamEventOutboxRepository, times(1)).save(any(StreamEventOutboxDocument.class));
         assertThat(changedResourceCaptor.getValue().getEvent().getType()).isEqualTo(EVENT_TYPE_DELETED);
     }
 
-        @Test
-        void replayOutboxEventsDeletesEventAfterSuccessfulReplay() throws Exception {
-                StreamEventOutboxDocument event = new StreamEventOutboxDocument();
-                event.setId("id-1");
-                event.setPayload("{\"resource_uri\":\"/company/123/persons-with-significant-control/individual/abc\"}");
-                ChangedResource changedResource = new ChangedResource();
-                changedResource.setResourceUri("/company/123/persons-with-significant-control/individual/abc");
+@Test
+void replayOutboxEventsDeletesEventAfterSuccessfulReplay() throws Exception {
+        StreamEventOutboxDocument event = new StreamEventOutboxDocument();
+        event.setId("id-1");
+        event.setPayload("{\"resource_uri\":\"/company/123/persons-with-significant-control/individual/abc\"}");
+        ChangedResource changedResource = new ChangedResource();
+        changedResource.setResourceUri("/company/123/persons-with-significant-control/individual/abc");
 
-                when(streamEventOutboxRepository.findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(any(Instant.class), any()))
-                                .thenReturn(List.of(event));
-                when(objectMapper.readValue(event.getPayload(), ChangedResource.class)).thenReturn(changedResource);
-                when(kafkaApiClientSupplier.get()).thenReturn(client);
-                when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
-                when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
-                when(privateChangedResourcePost.execute()).thenReturn(response);
+        when(streamEventOutboxRepository.findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(any(Instant.class), any())).thenReturn(List.of(event));
+        when(objectMapper.readValue(event.getPayload(), ChangedResource.class)).thenReturn(changedResource);
+        when(kafkaApiClientSupplier.get()).thenReturn(client);
+        when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
+        when(privateChangedResourcePost.execute()).thenReturn(response);
 
-                chsKafkaApiService.replayOutboxEvents();
+        chsKafkaApiService.replayOutboxEvents();
 
-                verify(streamEventOutboxRepository, times(1)).delete(event);
-        }
+        verify(streamEventOutboxRepository, times(1)).delete(event);
+}
 
-        @Test
-        void replayOutboxEventsReschedulesEventWhenReplayFails() throws Exception {
-                StreamEventOutboxDocument event = new StreamEventOutboxDocument();
-                event.setId("id-1");
-                event.setAttempts(0);
-                event.setPayload("{\"resource_uri\":\"/company/123/persons-with-significant-control/individual/abc\"}");
-                ChangedResource changedResource = new ChangedResource();
-                changedResource.setResourceUri("/company/123/persons-with-significant-control/individual/abc");
+@Test
+void replayOutboxEventsReschedulesEventWhenReplayFails() throws Exception {
+        StreamEventOutboxDocument event = new StreamEventOutboxDocument();
+        event.setId("id-1");
+        event.setAttempts(0);
+        event.setPayload("{\"resource_uri\":\"/company/123/persons-with-significant-control/individual/abc\"}");
+        ChangedResource changedResource = new ChangedResource();
+        changedResource.setResourceUri("/company/123/persons-with-significant-control/individual/abc");
 
-                RuntimeException runtimeException = new RuntimeException("kafka-api unavailable");
+        RuntimeException runtimeException = new RuntimeException("kafka-api unavailable");
 
-                when(streamEventOutboxRepository.findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(any(Instant.class), any()))
-                                .thenReturn(List.of(event));
-                when(objectMapper.readValue(event.getPayload(), ChangedResource.class)).thenReturn(changedResource);
-                when(kafkaApiClientSupplier.get()).thenReturn(client);
-                when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
-                when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
-                when(privateChangedResourcePost.execute()).thenThrow(runtimeException);
+        when(streamEventOutboxRepository.findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(any(Instant.class), any())).thenReturn(List.of(event));
+        when(objectMapper.readValue(event.getPayload(), ChangedResource.class)).thenReturn(changedResource);
+        when(kafkaApiClientSupplier.get()).thenReturn(client);
+        when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
+        when(privateChangedResourcePost.execute()).thenThrow(runtimeException);
 
-                chsKafkaApiService.replayOutboxEvents();
+        chsKafkaApiService.replayOutboxEvents();
 
-                verify(streamEventOutboxRepository, times(1)).save(event);
-                assertThat(event.getAttempts()).isEqualTo(1);
-                assertThat(event.getNextAttemptAt()).isNotNull();
-        }
+        verify(streamEventOutboxRepository, times(1)).save(event);
+        assertThat(event.getAttempts()).isEqualTo(1);
+        assertThat(event.getNextAttemptAt()).isNotNull();
+}
 
     @Test
     void invokeChsKafkaEndpointThrowsRuntimeException() throws ApiErrorResponseException {

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ChsKafkaApiServiceTest.java
@@ -18,7 +18,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import java.time.format.DateTimeFormatter;
+import java.time.Instant;
+import java.util.List;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -26,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.InternalApiClient;
@@ -46,6 +48,8 @@ import uk.gov.companieshouse.api.psc.SuperSecureBeneficialOwner;
 import uk.gov.companieshouse.pscdataapi.exceptions.ServiceUnavailableException;
 import uk.gov.companieshouse.pscdataapi.models.PscDeleteRequest;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.StreamEventOutboxDocument;
+import uk.gov.companieshouse.pscdataapi.repository.StreamEventOutboxRepository;
 import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
 import uk.gov.companieshouse.pscdataapi.util.TestHelper;
 
@@ -58,8 +62,8 @@ class ChsKafkaApiServiceTest {
     private static final String PSC_URI = "/company/%s/persons-with-significant-control/%s/%s";
     private static final DateTimeFormatter ROUNDED_TO_SECONDS_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        private final int outboxBatchSize = 50;
 
-    @InjectMocks
     private ChsKafkaApiService chsKafkaApiService;
 
     @Mock
@@ -68,6 +72,8 @@ class ChsKafkaApiServiceTest {
     private ObjectMapper objectMapper;
     @Mock
     private CompanyPscTransformer companyPscTransformer;
+        @Mock
+        private StreamEventOutboxRepository streamEventOutboxRepository;
 
     @Mock
     private InternalApiClient client;
@@ -82,6 +88,17 @@ class ChsKafkaApiServiceTest {
 
     @Captor
     ArgumentCaptor<ChangedResource> changedResourceCaptor;
+
+        @BeforeEach
+        void setUp() {
+                chsKafkaApiService = new ChsKafkaApiService(
+                                companyPscTransformer,
+                                kafkaApiClientSupplier,
+                                objectMapper,
+                                streamEventOutboxRepository,
+                                outboxBatchSize
+                );
+        }
 
     @Test
     void invokeChsKafkaEndpoint() throws ApiErrorResponseException {
@@ -416,6 +433,7 @@ class ChsKafkaApiServiceTest {
         verify(client, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
+                verify(streamEventOutboxRepository, times(1)).save(any(StreamEventOutboxDocument.class));
         assertThat(changedResourceCaptor.getValue().getEvent().getType()).isEqualTo(EVENT_TYPE_CHANGED);
     }
 
@@ -436,8 +454,56 @@ class ChsKafkaApiServiceTest {
         verify(client, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(any(), changedResourceCaptor.capture());
         verify(privateChangedResourcePost, times(1)).execute();
+                verify(streamEventOutboxRepository, times(1)).save(any(StreamEventOutboxDocument.class));
         assertThat(changedResourceCaptor.getValue().getEvent().getType()).isEqualTo(EVENT_TYPE_DELETED);
     }
+
+        @Test
+        void replayOutboxEventsDeletesEventAfterSuccessfulReplay() throws Exception {
+                StreamEventOutboxDocument event = new StreamEventOutboxDocument();
+                event.setId("id-1");
+                event.setPayload("{\"resource_uri\":\"/company/123/persons-with-significant-control/individual/abc\"}");
+                ChangedResource changedResource = new ChangedResource();
+                changedResource.setResourceUri("/company/123/persons-with-significant-control/individual/abc");
+
+                when(streamEventOutboxRepository.findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(any(Instant.class), any()))
+                                .thenReturn(List.of(event));
+                when(objectMapper.readValue(event.getPayload(), ChangedResource.class)).thenReturn(changedResource);
+                when(kafkaApiClientSupplier.get()).thenReturn(client);
+                when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+                when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
+                when(privateChangedResourcePost.execute()).thenReturn(response);
+
+                chsKafkaApiService.replayOutboxEvents();
+
+                verify(streamEventOutboxRepository, times(1)).delete(event);
+        }
+
+        @Test
+        void replayOutboxEventsReschedulesEventWhenReplayFails() throws Exception {
+                StreamEventOutboxDocument event = new StreamEventOutboxDocument();
+                event.setId("id-1");
+                event.setAttempts(0);
+                event.setPayload("{\"resource_uri\":\"/company/123/persons-with-significant-control/individual/abc\"}");
+                ChangedResource changedResource = new ChangedResource();
+                changedResource.setResourceUri("/company/123/persons-with-significant-control/individual/abc");
+
+                RuntimeException runtimeException = new RuntimeException("kafka-api unavailable");
+
+                when(streamEventOutboxRepository.findByNextAttemptAtLessThanEqualOrderByCreatedAtAsc(any(Instant.class), any()))
+                                .thenReturn(List.of(event));
+                when(objectMapper.readValue(event.getPayload(), ChangedResource.class)).thenReturn(changedResource);
+                when(kafkaApiClientSupplier.get()).thenReturn(client);
+                when(client.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
+                when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(privateChangedResourcePost);
+                when(privateChangedResourcePost.execute()).thenThrow(runtimeException);
+
+                chsKafkaApiService.replayOutboxEvents();
+
+                verify(streamEventOutboxRepository, times(1)).save(event);
+                assertThat(event.getAttempts()).isEqualTo(1);
+                assertThat(event.getNextAttemptAt()).isNotNull();
+        }
 
     @Test
     void invokeChsKafkaEndpointThrowsRuntimeException() throws ApiErrorResponseException {

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/api/ResourceChangedApiServiceAspectFeatureFlagDisabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/api/ResourceChangedApiServiceAspectFeatureFlagDisabledIT.java
@@ -10,10 +10,10 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,14 +27,15 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.psc.Individual;
 import uk.gov.companieshouse.api.sdk.ApiClientService;
 import uk.gov.companieshouse.pscdataapi.models.PscDeleteRequest;
+import uk.gov.companieshouse.pscdataapi.repository.StreamEventOutboxRepository;
 import uk.gov.companieshouse.pscdataapi.transform.CompanyPscTransformer;
 import uk.gov.companieshouse.pscdataapi.util.TestHelper;
 
 @SpringBootTest
 class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
 
-    @InjectMocks
     private ChsKafkaApiService chsKafkaApiService;
+    private final int outboxBatchSize = 50;
 
     @Captor
     ArgumentCaptor<ChangedResource> changedResourceCaptor;
@@ -56,6 +57,19 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
     private ObjectMapper objectMapper;
     @Mock
     private CompanyPscTransformer companyPscTransformer;
+    @Mock
+    private StreamEventOutboxRepository streamEventOutboxRepository;
+
+    @BeforeEach
+    void setUp() {
+        chsKafkaApiService = new ChsKafkaApiService(
+                companyPscTransformer,
+                kafkaApiClientSupplier,
+                objectMapper,
+                streamEventOutboxRepository,
+                outboxBatchSize
+        );
+    }
 
     @Test
     void testThatKafkaApiShouldBeCalledWhenFeatureFlagDisabled() throws ApiErrorResponseException {
@@ -101,7 +115,7 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledIT {
         verify(client).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), changedResourceCaptor.capture());
         verify(changedResourcePost, times(1)).execute();
-        verify(companyPscTransformer, times(2)).transformPscDocToIndividual(any(), eq(false));
+        verify(companyPscTransformer, times(1)).transformPscDocToIndividual(any(), eq(false));
 
         ChangedResource captured = changedResourceCaptor.getValue();
         assertThat(captured.getEvent().getType()).isEqualTo("deleted");


### PR DESCRIPTION
During testing of BI-[15067](https://companieshouse.atlassian.net/browse/BI-15067), testers found that after scaling down chs-kafka-api, sending a delete request and scaling back up, nothing was coming through the stream. Ticket description assumed kafka resilience model came into play which is not actually happening.

Main issue: failed events were not being persisted for retry, so delete requests that were happening while chs-kafka-api was down were just being lost from the stream. Because psc-data-api doesn’t write directly to kafka and is calling chs-kafka-api over HTTP, then when those requests failed with a 503 (because service intentionally scaled down), the message was not entering Kafka at all and so not attempting redelivery. 

Current delete flow - if Mongo record already gone, the delete still built a fallback PSC document and tried to publish a delete event in CompanyPscService - however, publishing to chs-kafka-api was basically one shot and on 503, ServiceUnavailable is thrown and it stops.
Basically, there was partial resilience, but only around payload construction, not around downstream outage/replay.

Fix:

- Using kafka outbox pattern to persist event locally and then keep event in outbox, retrying until it gets a successful response. 
- Tests have been extended to verify failed publish persistence and successful replay of the delete
- Tested locally in docker - confirmed delete event was queued in stream_event_outbox during chs-kafka-api downtime (stopped manually in docker) and automatically replayed after recovery (manually restarted) (outbox count went from 1 -> 0) and checked record was absent from primary search locally as well