### PR TITLE
Feature/bi 15146 amend psc data api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <!-- Internal -->
     <structured-logging.version>3.0.51</structured-logging.version>
     <opentelemetry-instrumentation-bom.version>2.26.1</opentelemetry-instrumentation-bom.version>
-    <private-api-sdk-java.version>6.0.22</private-api-sdk-java.version>
+    <private-api-sdk-java.version>6.0.31</private-api-sdk-java.version>
     <api-sdk-java.version>6.6.22</api-sdk-java.version>
     <api-security-java.version>2.0.21</api-security-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/models/PscDocument.java
@@ -1,10 +1,12 @@
 package uk.gov.companieshouse.pscdataapi.models;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Objects;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Document(collection = "delta_company_pscs")
@@ -16,6 +18,9 @@ public class PscDocument {
     @Field("psc_id")
     private String pscId;
 
+    @Field("previous_psc_id")
+    private String previousPscId;
+
     @Field("delta_at")
     private String deltaAt;
 
@@ -24,6 +29,12 @@ public class PscDocument {
 
     @Field("company_number")
     private String companyNumber;
+
+    @Field("company_name")
+    private String companyName;
+
+    @Field("company_status")
+    private String companyStatus;
 
     @Field("updated_by")
     private String updatedBy;
@@ -57,6 +68,14 @@ public class PscDocument {
         this.pscId = pscId;
     }
 
+    public String getPreviousPscId() {
+        return previousPscId;
+    }
+
+    public void setPreviousPscId(String previousPscId) {
+        this.previousPscId = previousPscId;
+    }
+
     public String getDeltaAt() {
         return deltaAt;
     }
@@ -79,6 +98,22 @@ public class PscDocument {
 
     public void setCompanyNumber(String companyNumber) {
         this.companyNumber = companyNumber;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getCompanyStatus() {
+        return companyStatus;
+    }
+
+    public void setCompanyStatus(String companyStatus) {
+        this.companyStatus = companyStatus;
     }
 
     public Created getCreated() {
@@ -130,6 +165,9 @@ public class PscDocument {
                 + ", pscId='"
                 + pscId
                 + '\''
+                + ", previousPscId='"
+                + previousPscId
+                + '\''
                 + ", deltaAt='"
                 + deltaAt
                 + '\''
@@ -138,6 +176,12 @@ public class PscDocument {
                 + '\''
                 + ", companyNumber='"
                 + companyNumber
+                + '\''
+                + ", companyName='"
+                + companyName
+                + '\''
+                + ", companyStatus='"
+                + companyStatus
                 + '\''
                 + ", updatedBy='"
                 + updatedBy
@@ -164,9 +208,12 @@ public class PscDocument {
         PscDocument that = (PscDocument) object;
         return Objects.equals(id, that.id)
                 && Objects.equals(pscId, that.pscId)
+                && Objects.equals(previousPscId, that.previousPscId)
                 && Objects.equals(deltaAt, that.deltaAt)
                 && Objects.equals(notificationId, that.notificationId)
                 && Objects.equals(companyNumber, that.companyNumber)
+                && Objects.equals(companyName, that.companyName)
+                && Objects.equals(companyStatus, that.companyStatus)
                 && Objects.equals(updatedBy, that.updatedBy)
                 && Objects.equals(created, that.created)
                 && Objects.equals(updated, that.updated)
@@ -176,7 +223,7 @@ public class PscDocument {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, pscId, deltaAt, notificationId, companyNumber,
+        return Objects.hash(id, pscId, previousPscId, deltaAt, notificationId, companyNumber, companyName, companyStatus,
                 updatedBy, created, updated, data, sensitiveData);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformer.java
@@ -420,7 +420,10 @@ public class CompanyPscTransformer {
 
         if (externalData != null) {
             pscDocument.setPscId(externalData.getPscId());
+            pscDocument.setPreviousPscId(externalData.getPreviousPscId());
             pscDocument.setCompanyNumber(externalData.getCompanyNumber());
+            pscDocument.setCompanyName(externalData.getCompanyName());
+            pscDocument.setCompanyStatus(externalData.getCompanyStatus());
 
             Data data = externalData.getData();
             if (data != null) {

--- a/src/test/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscdataapi/transform/CompanyPscTransformerTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -268,6 +267,9 @@ class CompanyPscTransformerTest {
 
         assertThat(result.getSensitiveData(), is(expectedDocument.getSensitiveData()));
         assertThat(result.getData().getIdentification(), is(expectedDocument.getData().getIdentification()));
+        assertThat(result.getPreviousPscId(), is(expectedDocument.getPreviousPscId()));
+        assertThat(result.getCompanyName(), is(expectedDocument.getCompanyName()));
+        assertThat(result.getCompanyStatus(), is(expectedDocument.getCompanyStatus()));
 
         assertThat(result.getDeltaAt(), is(expectedDocument.getDeltaAt()));
         assertThat(result.getUpdatedBy(), is(expectedDocument.getUpdatedBy()));
@@ -294,7 +296,10 @@ class CompanyPscTransformerTest {
         ExternalData externalData = new ExternalData();
         externalData.setData(null);
         externalData.setPscId("pscId123");
+        externalData.setPreviousPscId("previousPscId123");
         externalData.setCompanyNumber("12345678");
+        externalData.setCompanyName("TEST COMPANY LTD");
+        externalData.setCompanyStatus("active");
         requestBody.setExternalData(externalData);
         String notificationId = "notif-001";
 
@@ -304,8 +309,33 @@ class CompanyPscTransformerTest {
         Assertions.assertEquals("notif-001", result.getId());
         Assertions.assertEquals("notif-001", result.getNotificationId());
         Assertions.assertEquals("pscId123", result.getPscId());
+        Assertions.assertEquals("previousPscId123", result.getPreviousPscId());
         Assertions.assertEquals("12345678", result.getCompanyNumber());
+        Assertions.assertEquals("TEST COMPANY LTD", result.getCompanyName());
+        Assertions.assertEquals("active", result.getCompanyStatus());
         assertNull(result.getData());
+    }
+
+    @Test
+    void transformPscOnInsertShouldHandleNullPreviousPscId() {
+        FullRecordCompanyPSCApi requestBody =
+                TestHelper.buildFullRecordPsc(TestHelper.INDIVIDUAL_KIND,
+                        SHOW_FULL_DOB_TRUE, true);
+
+        ExternalData externalData = requestBody.getExternalData();
+        if (externalData != null) {
+            externalData.setPreviousPscId(null);
+            externalData.setCompanyName("TEST COMPANY LTD");
+            externalData.setCompanyStatus("active");
+        }
+
+        PscDocument result =
+                pscTransformer.transformPscOnInsert(NOTIFICATION_ID, requestBody);
+
+        assertNotNull(result);
+        assertNull(result.getPreviousPscId());
+        Assertions.assertEquals("TEST COMPANY LTD", result.getCompanyName());
+        Assertions.assertEquals("active", result.getCompanyStatus());
     }
 
     @Test


### PR DESCRIPTION
Fulfils  [BI-15146](https://companieshouse.atlassian.net/browse/BI-15146)   

- Extended PSC delta processing to map previous_psc_id, company_name, and company_status from ExternalData into     PscDocument, allowing fields to be persisted in Mongo. 

- Added unit tests covering populated and null previous_psc_id scenarios.

[BI-15146]: https://companieshouse.atlassian.net/browse/BI-15146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ