### PR TITLE
Add checks to sensitive data to stop crashes when retrieving PSC notifications where dob is missing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscdataapi/pscnotifications/PscNotificationsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/pscnotifications/PscNotificationsMapper.java
@@ -5,6 +5,7 @@ import static java.util.Optional.ofNullable;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.psc_notifications.NotificationList;
 import uk.gov.companieshouse.pscdataapi.models.PscDocument;
+import uk.gov.companieshouse.pscdataapi.models.PscSensitiveData;
 import uk.gov.companieshouse.pscdataapi.pscnotifications.mappers.DateOfBirthMapper;
 import uk.gov.companieshouse.pscdataapi.pscnotifications.mappers.ItemsMapper;
 import uk.gov.companieshouse.pscdataapi.pscnotifications.mappers.LinksMapper;
@@ -32,7 +33,12 @@ class PscNotificationsMapper {
                         .map(data -> new NotificationList()
                                 .activeCount(mapperRequest.activeCount())
                                 .ceasedCount(mapperRequest.ceasedCount())
-                                .dateOfBirth(dobMapper.map(firstNotification.getSensitiveData().getDateOfBirth()))
+                                .dateOfBirth(
+                                        ofNullable(firstNotification.getSensitiveData())
+                                                .map(PscSensitiveData::getDateOfBirth)
+                                                .map(dobMapper::map)
+                                                .orElse(null)
+                                )
                                 .inactiveCount(mapperRequest.inactiveCount())
                                 .items(itemsMapper.map(mapperRequest.pscNotifications()))
                                 .itemsPerPage(mapperRequest.itemsPerPage())

--- a/src/main/java/uk/gov/companieshouse/pscdataapi/pscnotifications/mappers/DateOfBirthMapper.java
+++ b/src/main/java/uk/gov/companieshouse/pscdataapi/pscnotifications/mappers/DateOfBirthMapper.java
@@ -6,10 +6,14 @@ import uk.gov.companieshouse.api.psc_notifications.DateOfBirth;
 @Component
 public class DateOfBirthMapper {
     public DateOfBirth map(uk.gov.companieshouse.pscdataapi.models.DateOfBirth dob) {
-        if (dob == null) return null;
-        // Map fields as appropriate
+        if (dob == null || isEmpty(dob)) return null;
+
         return new DateOfBirth()
                 .month(dob.getMonth())
                 .year(dob.getYear());
+    }
+
+    private boolean isEmpty(uk.gov.companieshouse.pscdataapi.models.DateOfBirth dob) {
+        return dob.getDay() == null && dob.getMonth() == null && dob.getYear() == null;
     }
 }


### PR DESCRIPTION
Added checks to mapPscNotifications to ensure sensitive data doesn't cause issues if missing or null

## Brief description of the change(s)
Added empty check to DateOfBirthMapper
Added ofNullable clause to PscNotificationsMapper



## Jira ticket

https://companieshouse.atlassian.net/jira/software/c/projects/GCI/boards/453?selectedIssue=BI-15041

## Test notes




## Checklist
>
> Paste the ⭕️ emoji into the respective columns below. If a checklist item *is* applicable but you haven't done it, omit the emoji from both columns. You can optionally add notes to clear up ambiguity. Whitespace isn't important, as long as the emoji is within the cell `|  |` it will render correctly.

| Item                                                       | Done | Not applicable | Notes |
|:-----------------------------------------------------------|:----:|:--------------:|-------|
| Adhered to the CH style guide (required)                   |  ⭕️  |                |       |
| Added/updated logging                                      |   ⭕️   |                |       |
| Written tests                                              |      |         ⭕️       |       |
| Tested the new code in my local environment                |  ⭕️    |                |       |
| Updated Docker/ECS configs                                 |      |           ⭕️     |       |
| Updated release ticket description with any config changes |      |        ⭕️        |       |
| Updated release ticket to link to this work item           |      |     ⭕️           |       |
